### PR TITLE
Initialize the Store lazily on first collect/dispatch

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -34,11 +34,9 @@ interface Store<S : State, A : Action, E : Event> {
     /**
      * Collects state changes.
      *
-     * @param skipInitialState Whether to skip the initial state
-     * @param startStore Whether to start the Store with this call
      * @param state Callback called when the state changes
      */
-    fun collectState(skipInitialState: Boolean = false, startStore: Boolean = true, state: (S) -> Unit)
+    fun collectState(state: (S) -> Unit)
 
     /**
      * Collects events.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -1,6 +1,7 @@
 package io.yumemi.tart.core
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -53,15 +54,44 @@ class StoreBaseTest {
     }
 
     @Test
+    fun tartStore_shouldProcessInitialEnterWhenCollectingState() = runTest(testDispatcher) {
+        val store = createTestStore(AppState.Loading)
+
+        // Store is not started
+        assertIs<AppState.Loading>(store.currentState)
+
+        // start Store
+        store.collectState { }
+
+        // Store is started
+        assertIs<AppState.Main>(store.currentState)
+    }
+
+    @Test
+    fun tartStore_shouldProcessInitialEnterWhenCollectingStateFlow() = runTest(testDispatcher) {
+        val store = createTestStore(AppState.Loading)
+
+        // Store is not started
+        assertIs<AppState.Loading>(store.currentState)
+
+        val collectingJob = launch {
+            // start Store
+            store.state.collect { }
+        }
+
+        assertIs<AppState.Main>(store.currentState)
+
+        collectingJob.cancel()
+    }
+
+    @Test
     fun tartStore_shouldHandleActions() = runTest(testDispatcher) {
         val store = createTestStore(AppState.Loading)
 
         // Store is not started
         assertIs<AppState.Loading>(store.currentState)
 
-        // Accessing state initializes the Store and runs Loading.enter
-        assertIs<AppState.Main>(store.state.value)
-
+        // start Store and handle action
         store.dispatch(AppAction.Increment)
         store.dispatch(AppAction.Increment)
         store.dispatch(AppAction.Decrement)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
@@ -39,7 +39,7 @@ class StoreExceptionTest {
             },
         )
 
-        store.state // access state to initialize the store
+        store.collectState { } // start Store
 
         assertNotNull(handledException)
     }

--- a/tart-message/src/commonTest/kotlin/io/yumemi/tart/message/MessageMiddlewareTest.kt
+++ b/tart-message/src/commonTest/kotlin/io/yumemi/tart/message/MessageMiddlewareTest.kt
@@ -27,7 +27,7 @@ class MessageMiddlewareTest {
 
         val store = createTestStore(CounterState(10), middleware, sendMessage)
 
-        store.state // access state to initialize the store
+        store.collectState { } // start Store
 
         assertEquals(sendMessage, receivedMessage)
     }


### PR DESCRIPTION
## Summary
- Initialize `Store` lazily on first `collectState`, `state.collect`, or `dispatch`.
- Simplify `collectState` to `collectState(state: (S) -> Unit)` by removing `skipInitialState` / `startStore` options.
- Make initial startup deterministic by running `onStart` and `onStateEntered` once via `initializeIfNeeded()` under mutex control.

## Tests
- Added tests to verify startup on `collectState` and on `state.collect`.
- Kept action handling coverage and updated existing tests to start the store via `collectState { }`.