### PR TITLE
Revert changes to the ViewStore constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,9 +648,9 @@ Create an instance of `ViewStore` directly with the target *State*.
 fun LoadingPreview() {
     MyApplicationTheme {
         CounterScreen(
-            viewStore = ViewStore {
-                CounterState.Loading
-            },
+            viewStore = ViewStore(
+                state = CounterState.Loading,
+            ),
         )
     }
 }

--- a/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
+++ b/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
@@ -19,33 +19,17 @@ import kotlinx.coroutines.flow.filter
  * Store wrapper class for use with Compose UI.
  * Provides state, action dispatching, and event handling.
  *
- * For Compose previews, you can create a ViewStore with state only.
- * ```
- * @Preview
- * @Composable
- * fun MyScreenPreview() {
- *     MyScreen(
- *         viewStore = ViewStore { MyState.Loading }
- *     )
- * }
- * ```
- *
+ * @param state The current state
  * @param dispatch Function to dispatch actions
  * @param eventFlow Flow to receive events
- * @param state Lambda that provides the current UI state
  */
 @Suppress("unused")
 @Stable
 class ViewStore<S : State, A : Action, E : Event>(
+    val state: S,
     val dispatch: (A) -> Unit = {},
     @PublishedApi internal val eventFlow: Flow<E> = emptyFlow(),
-    state: () -> S,
 ) {
-    /**
-     * Current UI state.
-     */
-    val state: S = state()
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ViewStore<*, *, *>) return false
@@ -119,9 +103,9 @@ fun <S : State, A : Action, E : Event> rememberViewStore(key: Any? = null, autoD
 
     return remember(state) {
         ViewStore(
+            state = state,
             dispatch = rememberedStore::dispatch,
             eventFlow = rememberedStore.event,
-            state = { state },
         )
     }
 }

--- a/tart-compose/src/commonTest/kotlin/io/yumemi/tart/compose/ViewStoreTest.kt
+++ b/tart-compose/src/commonTest/kotlin/io/yumemi/tart/compose/ViewStoreTest.kt
@@ -14,9 +14,9 @@ class ViewStoreTest {
 
     @Test
     fun viewStore_equalsWorksCorrectly() = runTest(testDispatcher) {
-        val viewStore1 = ViewStore<CounterState, Nothing, Nothing> { CounterState(10) }
-        val viewStore2 = ViewStore<CounterState, Nothing, Nothing> { CounterState(10) }
-        val viewStore3 = ViewStore<CounterState, Nothing, Nothing> { CounterState(20) }
+        val viewStore1 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(10))
+        val viewStore2 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(10))
+        val viewStore3 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(20))
 
         assertEquals(viewStore1, viewStore2)
         assertNotEquals(viewStore1, viewStore3)


### PR DESCRIPTION
## Summary
- Revert the `ViewStore` constructor API change and switch back to passing `state` as a value.
- Keep the README example consistent with the reverted constructor.

## Changes
- Updated `ViewStore` in `tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt` to use `state: S` instead of `state: () -> S`.
- Removed deferred state initialization (`val state: S = state()`) and stored `state` directly as a constructor property.
- Updated `rememberViewStore` to pass `state = state` when creating `ViewStore`.
- Updated the preview snippet in `README.md` to use `ViewStore(state = CounterState.Loading)`.

## Verification
- Code review of the diff for API reversion consistency in implementation and docs.
