### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 
 ### Collecting Flows
 
-You can use the `launch{}` specification in the `enter{}` block to collect flows and dispatch *Actions*.
+You can use the `launch{}` specification in the `enter{}` block to collect flows and update *State* (or emit *Event*s).
 This is useful for connecting external data streams to your *Store*:
 
 ```kt
@@ -725,8 +725,8 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 
 Note that *State* is read-only in Middleware.
 
-Each Middleware method is a suspending function, so it can be run synchronously (not asynchronously) with the *Store*.
-Because it runs synchronously and can block the *Store*, use a separate CoroutineScope for long-running work.
+Middleware methods are suspending functions. The *Store* waits for a method to complete before proceeding.
+Because a long-running method can block the *Store*, run heavy work in a separate CoroutineScope.
 
 In the next section, we introduce built-in Middleware.
 The source code is the `:tart-logging` and `:tart-message` modules in this repository, so you can use it as a reference for your Middleware implementation.


### PR DESCRIPTION
## Summary
- Clarify that middleware methods are suspend functions and that the Store waits for completion before proceeding.
- Fix the flow collection section to describe updating state/emitting events instead of dispatching actions in enter.launch scope.

## Why
- Align README explanations with actual Tart DSL behavior and reduce ambiguity.