### PR TITLE
Proposal: add action debounce/throttle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ By combining Tart with Kotlin `sealed class`/`sealed interface`, you can model e
   - [Multiple states and transitions](#multiple-states-and-transitions)
   - [Error handling](#error-handling)
   - [Collecting Flows](#collecting-flows)
+  - [Action Dispatch Controls](#action-dispatch-controls)
   - [Specifying coroutineContext](#specifying-coroutinecontext)
     - [Specifying CoroutineDispatchers](#specifying-coroutinedispatchers)
   - [State Persistence](#state-persistence)
@@ -396,6 +397,33 @@ state<MyState.Active> {
 
 This pattern lets your *Store* react to external data changes automatically, such as database updates, user preference changes, or network events.
 The flow collection will be automatically cancelled when the *State* changes to a different *State*, making it easy to manage resources and subscriptions.
+
+### Action Dispatch Controls
+
+Use `debounceAction()` or `throttleAction()` when you want to limit how frequently Actions are processed.
+
+```kt
+val store: Store<SearchState, SearchAction, Nothing> = Store {
+    initialState(SearchState())
+
+    debounceAction<SearchAction.QueryChanged>(timeoutMillis = 300)
+    throttleAction<SearchAction.Submit>(timeoutMillis = 1_000)
+
+    state<SearchState> {
+        action<SearchAction.QueryChanged> {
+            nextState(state.copy(query = action.query))
+        }
+        action<SearchAction.Submit> {
+            // execute search
+        }
+    }
+}
+```
+
+`debounceAction()` dispatches only the last Action in the window.  
+`throttleAction()` allows at most one Action in the window.
+
+You can also use the predicate-based overload to target arbitrary conditions and provide `keySelector` if you need separate windows per key.
 
 ### Specifying coroutineContext
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ActionDispatchController.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ActionDispatchController.kt
@@ -1,0 +1,93 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal interface ActionDispatchController<A : Action> {
+    fun attach(
+        coroutineScope: CoroutineScope,
+        dispatchBypassControllers: (A) -> Unit,
+    )
+
+    fun shouldDispatch(action: A): Boolean
+
+    fun onDispose()
+}
+
+internal class DebounceActionDispatchController<A : Action>(
+    private val timeoutMillis: Long,
+    private val predicate: (A) -> Boolean,
+    private val keySelector: (A) -> Any?,
+) : ActionDispatchController<A> {
+
+    private var attachedCoroutineScope: CoroutineScope? = null
+    private var attachedDispatchBypassControllers: ((A) -> Unit)? = null
+
+    private val jobsByKey = mutableMapOf<Any?, Job>()
+
+    override fun attach(
+        coroutineScope: CoroutineScope,
+        dispatchBypassControllers: (A) -> Unit,
+    ) {
+        attachedCoroutineScope = coroutineScope
+        attachedDispatchBypassControllers = dispatchBypassControllers
+    }
+
+    override fun shouldDispatch(action: A): Boolean {
+        if (!predicate(action)) return true
+        val coroutineScope = attachedCoroutineScope ?: return true
+        val dispatchBypassControllers = attachedDispatchBypassControllers ?: return true
+
+        val key = keySelector(action)
+        jobsByKey.remove(key)?.cancel()
+        jobsByKey[key] = coroutineScope.launch {
+            delay(timeoutMillis)
+            dispatchBypassControllers(action)
+        }
+        return false
+    }
+
+    override fun onDispose() {
+        jobsByKey.values.forEach { it.cancel() }
+        jobsByKey.clear()
+    }
+}
+
+internal class ThrottleActionDispatchController<A : Action>(
+    private val timeoutMillis: Long,
+    private val predicate: (A) -> Boolean,
+    private val keySelector: (A) -> Any?,
+) : ActionDispatchController<A> {
+
+    private var attachedCoroutineScope: CoroutineScope? = null
+    private val activeWindowJobsByKey = mutableMapOf<Any?, Job>()
+
+    override fun attach(
+        coroutineScope: CoroutineScope,
+        dispatchBypassControllers: (A) -> Unit,
+    ) {
+        attachedCoroutineScope = coroutineScope
+    }
+
+    override fun shouldDispatch(action: A): Boolean {
+        if (!predicate(action)) return true
+
+        val coroutineScope = attachedCoroutineScope ?: return true
+        val key = keySelector(action)
+        val activeWindowJob = activeWindowJobsByKey[key]
+        if (activeWindowJob == null || !activeWindowJob.isActive) {
+            activeWindowJobsByKey[key] = coroutineScope.launch {
+                delay(timeoutMillis)
+            }
+            return true
+        }
+        return false
+    }
+
+    override fun onDispose() {
+        activeWindowJobsByKey.values.forEach { it.cancel() }
+        activeWindowJobsByKey.clear()
+    }
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -14,6 +14,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Default
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
+    private var storeActionDispatchControllers: MutableList<ActionDispatchController<A>> = mutableListOf()
 
     /**
      * Sets the initial state of the store.
@@ -67,6 +68,84 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
      */
     fun middlewares(vararg middleware: Middleware<S, A, E>) {
         storeMiddlewares.addAll(middleware)
+    }
+
+    /**
+     * Delays dispatching matching actions until no new matching action arrives for the timeout duration.
+     *
+     * @param timeoutMillis debounce timeout in milliseconds
+     * @param keySelector Optional key selector. Actions with the same key share the same debounce window
+     * @param predicate Predicate to determine whether the action should be debounced
+     */
+    fun debounceAction(
+        timeoutMillis: Long,
+        keySelector: (A) -> Any? = { it::class },
+        predicate: (A) -> Boolean = { true },
+    ) {
+        require(timeoutMillis > 0) { "[Tart] timeoutMillis must be greater than 0 for debounceAction()" }
+        storeActionDispatchControllers.add(
+            DebounceActionDispatchController(
+                timeoutMillis = timeoutMillis,
+                predicate = predicate,
+                keySelector = keySelector,
+            ),
+        )
+    }
+
+    /**
+     * Delays dispatching a specific action type until no new action of the same key arrives for the timeout duration.
+     *
+     * @param timeoutMillis debounce timeout in milliseconds
+     * @param keySelector Optional key selector for the target action type
+     */
+    inline fun <reified A2 : A> debounceAction(
+        timeoutMillis: Long,
+        noinline keySelector: (A2) -> Any? = { it::class },
+    ) {
+        debounceAction(
+            timeoutMillis = timeoutMillis,
+            keySelector = { action -> (action as? A2)?.let(keySelector) ?: Unit },
+            predicate = { it is A2 },
+        )
+    }
+
+    /**
+     * Allows dispatching matching actions at most once per timeout duration.
+     *
+     * @param timeoutMillis throttle timeout in milliseconds
+     * @param keySelector Optional key selector. Actions with the same key share the same throttle window
+     * @param predicate Predicate to determine whether the action should be throttled
+     */
+    fun throttleAction(
+        timeoutMillis: Long,
+        keySelector: (A) -> Any? = { it::class },
+        predicate: (A) -> Boolean = { true },
+    ) {
+        require(timeoutMillis > 0) { "[Tart] timeoutMillis must be greater than 0 for throttleAction()" }
+        storeActionDispatchControllers.add(
+            ThrottleActionDispatchController(
+                timeoutMillis = timeoutMillis,
+                predicate = predicate,
+                keySelector = keySelector,
+            ),
+        )
+    }
+
+    /**
+     * Allows dispatching a specific action type at most once per timeout duration.
+     *
+     * @param timeoutMillis throttle timeout in milliseconds
+     * @param keySelector Optional key selector for the target action type
+     */
+    inline fun <reified A2 : A> throttleAction(
+        timeoutMillis: Long,
+        noinline keySelector: (A2) -> Any? = { it::class },
+    ) {
+        throttleAction(
+            timeoutMillis = timeoutMillis,
+            keySelector = { action -> (action as? A2)?.let(keySelector) ?: Unit },
+            predicate = { it is A2 },
+        )
     }
 
     class StateHandler<P, SC : StoreScope>(
@@ -249,6 +328,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val stateSaver: StateSaver<S> = storeStateSaver
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
+            override val actionDispatchControllers: List<ActionDispatchController<A>> = storeActionDispatchControllers
             override val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
             override val onExit: suspend ExitScope<S, E, S>.() -> Unit = this@StoreBuilder.onExit

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -69,6 +69,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     protected abstract val exceptionHandler: ExceptionHandler
 
     protected abstract val middlewares: List<Middleware<S, A, E>>
+    protected abstract val actionDispatchControllers: List<ActionDispatchController<A>>
 
     protected abstract val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit
 
@@ -91,10 +92,17 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private val stateScopes = mutableMapOf<KClass<out S>, CoroutineScope>()
 
     final override fun dispatch(action: A) {
+        dispatch(action = action, bypassActionDispatchControllers = false)
+    }
+
+    private fun dispatch(action: A, bypassActionDispatchControllers: Boolean) {
         coroutineScope.launch {
             mutex.withLock {
                 initializeIfNeeded()
-                onActionDispatched(currentState, action)
+                val shouldDispatch = bypassActionDispatchControllers || actionDispatchControllers.all { it.shouldDispatch(action) }
+                if (shouldDispatch) {
+                    onActionDispatched(currentState, action)
+                }
             }
         }
     }
@@ -112,6 +120,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     }
 
     final override fun dispose() {
+        actionDispatchControllers.forEach { it.onDispose() }
         coroutineScope.cancel()
     }
 
@@ -120,6 +129,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private suspend fun initializeIfNeeded() {
         if (isInitialized) return
         isInitialized = true
+        actionDispatchControllers.forEach { controller ->
+            controller.attach(coroutineScope) { action ->
+                dispatch(action = action, bypassActionDispatchControllers = true)
+            }
+        }
         processMiddleware {
             onStart(
                 object : MiddlewareScope<A> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ActionDispatchControlTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ActionDispatchControlTest.kt
@@ -1,0 +1,99 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ActionDispatchControlTest {
+
+    data class AppState(
+        val latestQuery: String = "",
+        val submitCount: Int = 0,
+        val incrementCount: Int = 0,
+    ) : State
+
+    sealed interface AppAction : Action {
+        data class Search(val query: String) : AppAction
+        data object Submit : AppAction
+        data object Increment : AppAction
+    }
+
+    private fun createStore(dispatcher: TestDispatcher): Store<AppState, AppAction, Nothing> {
+        return Store(AppState()) {
+            coroutineContext(dispatcher)
+            debounceAction<AppAction.Search>(timeoutMillis = 300)
+            throttleAction<AppAction.Increment>(timeoutMillis = 500)
+
+            state<AppState> {
+                action<AppAction.Search> {
+                    nextState(state.copy(latestQuery = action.query))
+                }
+                action<AppAction.Submit> {
+                    nextState(state.copy(submitCount = state.submitCount + 1))
+                }
+                action<AppAction.Increment> {
+                    nextState(state.copy(incrementCount = state.incrementCount + 1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun debounceAction_shouldDispatchOnlyLatestAction() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = createStore(dispatcher)
+
+        store.dispatch(AppAction.Search("h"))
+        runCurrent()
+        advanceTimeBy(100)
+        store.dispatch(AppAction.Search("he"))
+        runCurrent()
+        advanceTimeBy(100)
+        store.dispatch(AppAction.Search("hello"))
+        runCurrent()
+
+        assertEquals("", store.currentState.latestQuery)
+
+        store.dispatch(AppAction.Submit)
+        runCurrent()
+        assertEquals(1, store.currentState.submitCount)
+
+        advanceTimeBy(299)
+        runCurrent()
+        assertEquals("", store.currentState.latestQuery)
+
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals("hello", store.currentState.latestQuery)
+    }
+
+    @Test
+    fun throttleAction_shouldAllowAtMostOneActionPerWindow() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = createStore(dispatcher)
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+        assertEquals(1, store.currentState.incrementCount)
+
+        advanceTimeBy(499)
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+        assertEquals(1, store.currentState.incrementCount)
+
+        advanceTimeBy(1)
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+        assertEquals(2, store.currentState.incrementCount)
+    }
+}


### PR DESCRIPTION
## Proposal
Introduce built-in action dispatch controls for Store: `debounceAction()` and `throttleAction()`.

## What's included
- Add internal action dispatch controller layer in `tart-core`
- Add `debounceAction(...)` and `throttleAction(...)` DSL APIs to `StoreBuilder`
- Hook controllers into `StoreImpl.dispatch()` and lifecycle cleanup
- Add JVM tests for debounce/throttle behavior
- Update README with usage examples

## Verification
- ✅ `./gradlew :tart-core:jvmTest`

## Notes
- Existing action/state DSL remains unchanged
- Controls are opt-in and can be scoped by action type, predicate, and key selector