### PR TITLE
Add store overrides DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ It keeps surrounding helper layers intentionally small, so dependencies and feat
     - [Specifying CoroutineDispatchers](#specifying-coroutinedispatchers)
   - [State Persistence](#state-persistence)
   - [Clear Pending Actions](#clear-pending-actions)
+  - [Using Control Flow in Store{}](#using-control-flow-in-store)
   - [For Platforms Without Flow/StateFlow Access](#for-platforms-without-flowstateflow-access)
 - [Compose](#compose)
   - [Rendering with State](#rendering-with-state)
@@ -527,6 +528,22 @@ val store = Store<MyState, MyAction, MyEvent>(MyState.Initial) {
 ```
 
 Regardless of the configured `PendingActionPolicy`, you can still discard already queued actions at a specific point by calling `clearPendingActions()` inside `enter{}`, `action{}`, `exit{}`, `error{}`, or inside `transaction{}` from a launched coroutine.
+
+### Using Control Flow in `Store{}`
+
+The body of `Store{}` is ordinary Kotlin code, so you can use control flow such as `if` and `when` when specifying *Store* configuration.
+
+```kt
+fun CounterStore(
+    logExceptions: Boolean,
+): Store<CounterState, CounterAction, Nothing> = Store {
+    initialState(CounterState(count = 0))
+
+    if (logExceptions) {
+        exceptionHandler(ExceptionHandler.Log)
+    }
+}
+```
 
 ### For Platforms Without Flow/StateFlow Access
 

--- a/README.md
+++ b/README.md
@@ -797,7 +797,7 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
     )
 
     // add multiple Middlewares
-    middlewares(..., ...)
+    middleware(..., ...)
 }
 ```
 
@@ -898,19 +898,21 @@ val mainStore: Store<MainState, MainAction, MainEvent> = Store {
 In larger projects, it can be useful to wrap `Store(...)` in a project-specific `AppStore(...)`.
 
 This allows you to centralize shared behavior such as common middleware, exception handling, and state persistence.
-It also gives you a place to prepare an extra setup hook for testing and debugging.
+It also gives you a place to apply non-state overrides for testing and debugging.
 
 ```kt
 fun <S : State, A : Action, E : Event> AppStore(
     initialState: S,
-    extraSetup: Setup<S, A, E> = {},
+    overrides: Overrides<S, A, E> = {},
     setup: Setup<S, A, E>,
-): Store<S, A, E> = Store(initialState) {
+): Store<S, A, E> = Store(
+    initialState = initialState,
+    overrides = overrides,
+) {
     middleware(AppLoggingMiddleware())
     exceptionHandler(AppExceptionHandler)
 
     setup()
-    extraSetup()
 }
 ```
 
@@ -919,10 +921,10 @@ A feature Store can then focus on its own state transitions and actions:
 ```kt
 fun CounterStore(
     counterRepository: CounterRepository,
-    extraSetup: Setup<CounterState, CounterAction, CounterEvent> = {},
+    overrides: Overrides<CounterState, CounterAction, CounterEvent> = {},
 ): Store<CounterState, CounterAction, CounterEvent> = AppStore(
     initialState = CounterState(count = 0),
-    extraSetup = extraSetup,
+    overrides = overrides,
 ) {
     state<CounterState> {
         action<CounterAction.Increment> {
@@ -941,8 +943,9 @@ val recordedEvents = mutableListOf<CounterEvent>()
 
 val store = CounterStore(
     counterRepository = repository,
-    extraSetup = {
+    overrides = {
         coroutineContext(testDispatcher)
+        clearMiddlewares()
         middleware(
             Middleware(
                 afterEventEmit = { _, event ->
@@ -954,14 +957,17 @@ val store = CounterStore(
 )
 ```
 
+Use `replaceMiddlewares(...)` inside `overrides {}` when you want to replace the default middleware set.
+Use `clearMiddlewares()` when you want to remove all configured middleware.
+
 This pattern is useful for:
 
 - applying project-wide middleware and exception handling
 - injecting test- or debug-only middleware
+- overriding `stateSaver` or `exceptionHandler` for tests
 - overriding `coroutineContext` in tests
+- clearing or replacing default middleware via `clearMiddlewares()` / `replaceMiddlewares(...)`
 - keeping feature Store definitions focused on business logic
-
-Avoid using `extraSetup` to redefine `state {}` or `anyState {}` handlers, because handler selection depends on registration order.
 
 Also note that middleware execution order should not be relied on.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ It keeps surrounding helper layers intentionally small, so dependencies and feat
 - [Middleware](#middleware)
   - [Logging](#logging)
   - [Message](#message)
+- [Overrides](#overrides)
 - [Project-specific AppStore Wrapper](#project-specific-appstore-wrapper)
 - [Testing Store](#testing-store)
 
@@ -893,12 +894,53 @@ val mainStore: Store<MainState, MainAction, MainEvent> = Store {
 ```
 </details>
 
+## Overrides
+
+`Store{}` DSL accepts an `overrides` block that is applied after the main setup block.
+Use it when you want to override *Store* configuration.
+
+```kt
+fun CounterStore(
+    overrides: Overrides<CounterState, CounterAction, Nothing> = {},
+): Store<CounterState, CounterAction, Nothing> = Store(
+    initialState = CounterState(count = 0),
+    overrides = overrides,
+) {
+    middleware(AppLoggingMiddleware())
+
+    state<CounterState> {
+        // ...
+    }
+}
+
+val store = CounterStore()
+
+val testStore = CounterStore(
+    overrides = {
+        clearMiddlewares()
+        exceptionHandler(ExceptionHandler.Log)
+    },
+)
+```
+
+Inside `overrides` block, you can use these APIs:
+
+- `coroutineContext(...)`
+- `stateSaver(...)`
+- `exceptionHandler(...)`
+- `middleware(...)`
+- `clearMiddlewares()`
+- `replaceMiddlewares(...)`
+
+Typical uses are:
+
+- changing shared *Store* behavior in tests without rewriting the *Store* definition
+- injecting debug-only middleware or logging
+
 ## Project-specific AppStore Wrapper
 
-In larger projects, it can be useful to wrap `Store(...)` in a project-specific `AppStore(...)`.
-
-This allows you to centralize shared behavior such as common middleware, exception handling, and state persistence.
-It also gives you a place to apply non-state overrides for testing and debugging.
+In larger projects, it can be useful to wrap `Store{}` DSL in a project-specific `AppStore{}` that applies app-wide defaults in one place.
+This lets you centralize shared *Store* configuration.
 
 ```kt
 fun <S : State, A : Action, E : Event> AppStore(
@@ -909,6 +951,7 @@ fun <S : State, A : Action, E : Event> AppStore(
     initialState = initialState,
     overrides = overrides,
 ) {
+    // shared Store configuration
     middleware(AppLoggingMiddleware())
     exceptionHandler(AppExceptionHandler)
 
@@ -916,60 +959,31 @@ fun <S : State, A : Action, E : Event> AppStore(
 }
 ```
 
-A feature Store can then focus on its own state transitions and actions:
+A feature *Store* can then focus on its own state transitions and actions:
 
 ```kt
 fun CounterStore(
     counterRepository: CounterRepository,
     overrides: Overrides<CounterState, CounterAction, CounterEvent> = {},
-): Store<CounterState, CounterAction, CounterEvent> = AppStore(
+): Store<CounterState, CounterAction, CounterEvent> = AppStore( // use AppStore{}
     initialState = CounterState(count = 0),
     overrides = overrides,
 ) {
     state<CounterState> {
-        action<CounterAction.Increment> {
-            val count = state.count + 1
-            counterRepository.set(count)
-            nextState(state.copy(count = count))
-        }
+        // ...
     }
 }
-```
 
-For tests or debug builds, you can inject only the additional behavior you need:
+val store = CounterStore(counterRepository = counterRepository)
 
-```kt
-val recordedEvents = mutableListOf<CounterEvent>()
-
-val store = CounterStore(
-    counterRepository = repository,
+val testStore = CounterStore(
+    counterRepository = counterRepository,
     overrides = {
-        coroutineContext(testDispatcher)
         clearMiddlewares()
-        middleware(
-            Middleware(
-                afterEventEmit = { _, event ->
-                    recordedEvents += event
-                },
-            ),
-        )
+        // ...
     },
 )
 ```
-
-Use `replaceMiddlewares(...)` inside `overrides {}` when you want to replace the default middleware set.
-Use `clearMiddlewares()` when you want to remove all configured middleware.
-
-This pattern is useful for:
-
-- applying project-wide middleware and exception handling
-- injecting test- or debug-only middleware
-- overriding `stateSaver` or `exceptionHandler` for tests
-- overriding `coroutineContext` in tests
-- clearing or replacing default middleware via `clearMiddlewares()` / `replaceMiddlewares(...)`
-- keeping feature Store definitions focused on business logic
-
-Also note that middleware execution order should not be relied on.
 
 ## Testing Store
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -62,21 +62,24 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Adds a single middleware instance to the store.
+     * Adds one or more middleware instances to the store.
      *
-     * @param middleware The middleware instance to add
+     * @param first The first middleware instance to add
+     * @param rest Additional middleware instances to add
      */
-    fun middleware(middleware: Middleware<S, A, E>) {
-        storeMiddlewares.add(middleware)
+    fun middleware(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
+        storeMiddlewares.add(first)
+        storeMiddlewares.addAll(rest)
     }
 
-    /**
-     * Adds multiple middleware instances to the store.
-     *
-     * @param middleware Array of middleware instances to add
-     */
-    fun middlewares(vararg middleware: Middleware<S, A, E>) {
-        storeMiddlewares.addAll(middleware)
+    internal fun clearMiddlewares() {
+        storeMiddlewares.clear()
+    }
+
+    internal fun replaceMiddlewares(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
+        clearMiddlewares()
+        storeMiddlewares.add(first)
+        storeMiddlewares.addAll(rest)
     }
 
     class StateHandler<P, SC : StoreScope>(
@@ -368,32 +371,115 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
 typealias Setup<S, A, E> = StoreBuilder<S, A, E>.() -> Unit
 
 /**
- * Creates a Store instance with the specified initial state and optional setup.
+ * Store overrides block applied after the main Store setup.
+ * This block is limited to non-state configuration such as coroutine context,
+ * persistence, exception handling, and middleware.
+ */
+typealias Overrides<S, A, E> = StoreOverridesBuilder<S, A, E>.() -> Unit
+
+/**
+ * DSL for overriding Store configuration after the main setup has been applied.
+ * This DSL intentionally does not expose state/action handler APIs.
+ */
+@Suppress("unused")
+@TartStoreDsl
+class StoreOverridesBuilder<S : State, A : Action, E : Event> internal constructor() {
+    private val operations = mutableListOf<StoreBuilder<S, A, E>.() -> Unit>()
+
+    /**
+     * Overrides the coroutine context for store operations.
+     */
+    fun coroutineContext(coroutineContext: CoroutineContext) {
+        operations.add { coroutineContext(coroutineContext) }
+    }
+
+    /**
+     * Overrides the state saver used by the store.
+     */
+    fun stateSaver(stateSaver: StateSaver<S>) {
+        operations.add { stateSaver(stateSaver) }
+    }
+
+    /**
+     * Overrides the exception handler used by the store.
+     */
+    fun exceptionHandler(exceptionHandler: ExceptionHandler) {
+        operations.add { exceptionHandler(exceptionHandler) }
+    }
+
+    /**
+     * Adds one or more middleware instances after the main Store setup.
+     */
+    fun middleware(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
+        val restValues = rest.copyOf()
+        operations.add { middleware(first, *restValues) }
+    }
+
+    /**
+     * Replaces all middleware instances configured so far.
+     * This can be used to remove default middleware in tests or debug setups.
+     */
+    fun replaceMiddlewares(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
+        val restValues = rest.copyOf()
+        operations.add { replaceMiddlewares(first, *restValues) }
+    }
+
+    /**
+     * Clears all middleware instances configured so far.
+     * This can be used to remove default middleware in tests or debug setups.
+     */
+    fun clearMiddlewares() {
+        operations.add { clearMiddlewares() }
+    }
+
+    internal fun applyTo(builder: StoreBuilder<S, A, E>) {
+        operations.forEach { operation -> operation(builder) }
+    }
+}
+
+private fun <S : State, A : Action, E : Event> buildStore(
+    initialState: S? = null,
+    overrides: Overrides<S, A, E>? = null,
+    setup: Setup<S, A, E>,
+): Store<S, A, E> {
+    val builder = StoreBuilder<S, A, E>()
+    initialState?.let(builder::initialState)
+    builder.setup()
+    overrides?.let {
+        StoreOverridesBuilder<S, A, E>().apply(it).applyTo(builder)
+    }
+    return builder.build()
+}
+
+/**
+ * Creates a Store instance with the specified initial state and optional overrides.
+ * Overrides are applied after the main setup block.
  *
  * @param initialState The initial state of the store
- * @param setup Optional setup block to customize the store
+ * @param overrides Overrides block for non-state Store configuration
+ * @param setup Setup block to customize the store
  * @return A configured Store instance
  */
 fun <S : State, A : Action, E : Event> Store(
     initialState: S,
+    overrides: Overrides<S, A, E> = {},
     setup: Setup<S, A, E>,
 ): Store<S, A, E> {
-    return StoreBuilder<S, A, E>().apply {
-        initialState(initialState)
-        setup()
-    }.build()
+    return buildStore(initialState = initialState, overrides = overrides, setup = setup)
 }
 
 /**
- * Creates a Store instance with setup provided in the block.
+ * Creates a Store instance with setup provided in the block and optional overrides.
  * The initial state must be set within the block using initialState().
  *
+ * @param overrides Overrides block for non-state Store configuration
  * @param setup Setup block to customize the store
  * @return A configured Store instance
  * @throws IllegalArgumentException if the initial state is not set in the block
  */
 fun <S : State, A : Action, E : Event> Store(
+    overrides: Overrides<S, A, E> = {},
     setup: Setup<S, A, E>,
 ): Store<S, A, E> {
-    return StoreBuilder<S, A, E>().apply(setup).build()
+    return buildStore(overrides = overrides, setup = setup)
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
@@ -1,0 +1,164 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StoreOverridesTest {
+
+    data class AppState(val count: Int) : State
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+    }
+
+    private class RecordingStateSaver(
+        private val restoredState: AppState?,
+    ) : StateSaver<AppState> {
+        val savedStates = mutableListOf<AppState>()
+
+        override fun save(state: AppState) {
+            savedStates += state
+        }
+
+        override fun restore(): AppState? = restoredState
+    }
+
+    private fun recordingMiddleware(
+        name: String,
+        records: MutableList<String>,
+    ): Middleware<AppState, AppAction, Nothing> {
+        return Middleware(
+            afterActionDispatch = { _, _, _ ->
+                records += name
+            },
+        )
+    }
+
+    @Test
+    fun storeInitialStateOverload_shouldApplyOverridesAfterSetup() {
+        val setupSaver = RecordingStateSaver(restoredState = AppState(count = 100))
+        val overrideSaver = RecordingStateSaver(restoredState = AppState(count = 10))
+        val middlewareRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                coroutineContext(Dispatchers.Unconfined)
+                stateSaver(overrideSaver)
+                replaceMiddlewares(recordingMiddleware("override", middlewareRecords))
+            },
+        ) {
+            stateSaver(setupSaver)
+            middleware(recordingMiddleware("setup", middlewareRecords))
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        assertEquals(AppState(count = 10), store.currentState)
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(listOf("override"), middlewareRecords)
+        assertEquals(listOf(AppState(count = 11)), overrideSaver.savedStates)
+        assertTrue(setupSaver.savedStates.isEmpty())
+    }
+
+    @Test
+    fun storeDslInitialStateOverload_shouldApplyOverridesAndAllowMiddlewareAppendAfterReplacement() {
+        val setupSaver = RecordingStateSaver(restoredState = AppState(count = 100))
+        val overrideSaver = RecordingStateSaver(restoredState = AppState(count = 20))
+        val middlewareRecords = mutableListOf<String>()
+
+        val store = Store(
+            overrides = {
+                coroutineContext(Dispatchers.Unconfined)
+                stateSaver(overrideSaver)
+                replaceMiddlewares(recordingMiddleware("replacement", middlewareRecords))
+                middleware(recordingMiddleware("extra", middlewareRecords))
+            },
+        ) {
+            initialState(AppState(count = 0))
+            stateSaver(setupSaver)
+            middleware(recordingMiddleware("setup", middlewareRecords))
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        assertEquals(AppState(count = 20), store.currentState)
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(listOf("extra", "replacement"), middlewareRecords.sorted())
+        assertEquals(listOf(AppState(count = 21)), overrideSaver.savedStates)
+        assertTrue(setupSaver.savedStates.isEmpty())
+    }
+
+    @Test
+    fun clearMiddlewaresInOverrides_shouldClearPreviouslyConfiguredMiddlewares() {
+        val middlewareRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                clearMiddlewares()
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            middleware(recordingMiddleware("setup", middlewareRecords))
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertTrue(middlewareRecords.isEmpty())
+    }
+
+    @Test
+    fun middleware_shouldAcceptMultipleValuesInSetupAndOverrides() {
+        val middlewareRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                middleware(
+                    recordingMiddleware("override1", middlewareRecords),
+                    recordingMiddleware("override2", middlewareRecords),
+                )
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            middleware(
+                recordingMiddleware("setup1", middlewareRecords),
+                recordingMiddleware("setup2", middlewareRecords),
+            )
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(
+            listOf("override1", "override2", "setup1", "setup2"),
+            middlewareRecords.sorted(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add an overrides DSL for non-state store configuration while keeping Store { ... } and Store(initialState) { ... } usage intact.
- Support middleware replacement and clearing through replaceMiddlewares(...) and clearMiddlewares() inside overrides { }.
- Simplify middleware setup by allowing middleware(...) to accept one or more middleware instances.
- Add JVM tests for overrides behavior and update the README examples to use overrides instead of extraSetup.

## Verification
- ./gradlew :tart-core:jvmTest