### PR TITLE
Add store observer and recorder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,7 +979,7 @@ fun counterStore_recordsStatesAndEvents() = runTest {
     store.attachObserver(recorder)
 
     // When
-    store.dispatchAndAwait(CounterAction.Increment) // wait until the dispatched action completes
+    store.dispatchAndWait(CounterAction.Increment) // wait until the dispatched action completes
 
     // Then
     assertEquals(

--- a/README.md
+++ b/README.md
@@ -967,16 +967,14 @@ Also note that middleware execution order should not be relied on.
 
 ## Testing Store
 
-You can attach a `StoreRecorder` before the *Store* starts and use it to assert recorded state and event history.
+For most Store tests, use `attachRecorder()` to attach the default `StoreRecorder` and assert recorded state and event history.
 
 ```kt
 @Test
 fun counterStore_recordsStatesAndEvents() = runTest {
     // Given
-    val recorder = StoreRecorder<CounterState, CounterEvent>()
     val store = CounterStore(...)
-
-    store.attachObserver(recorder)
+    val recorder = store.attachRecorder()
 
     // When
     store.dispatchAndWait(CounterAction.Increment) // wait until the dispatched action completes
@@ -996,5 +994,5 @@ fun counterStore_recordsStatesAndEvents() = runTest {
 }
 ```
 
-If you need different recording behavior, you can also implement your own recorder by implementing `StoreObserver`.
+If you need custom recording behavior, you can implement your own recorder by implementing `StoreObserver`.
 If your `action {}` or `enter {}` logic launches additional coroutines with `launch {}`, or if you need virtual time control, use test dispatcher and scheduler control separately.

--- a/README.md
+++ b/README.md
@@ -970,16 +970,18 @@ Also note that middleware execution order should not be relied on.
 You can attach a `StoreRecorder` before the *Store* starts and use it to assert recorded state and event history.
 
 ```kt
-@OptIn(ExperimentalTartApi::class)
 @Test
-fun counterStore_recordsStateHistory() = runTest {
+fun counterStore_recordsStatesAndEvents() = runTest {
+    // Given
     val recorder = StoreRecorder<CounterState, CounterEvent>()
     val store = CounterStore(...)
 
     store.attachObserver(recorder)
 
-    store.dispatch(CounterAction.Increment)
+    // When
+    store.dispatchAndAwait(CounterAction.Increment) // wait until the dispatched action completes
 
+    // Then
     assertEquals(
         listOf(
             CounterState(count = 0),
@@ -995,3 +997,4 @@ fun counterStore_recordsStateHistory() = runTest {
 ```
 
 If you need different recording behavior, you can also implement your own recorder by implementing `StoreObserver`.
+If your `action {}` or `enter {}` logic launches additional coroutines with `launch {}`, or if you need virtual time control, use test dispatcher and scheduler control separately.

--- a/README.md
+++ b/README.md
@@ -967,5 +967,31 @@ Also note that middleware execution order should not be relied on.
 
 ## Testing Store
 
-Tart's architecture makes writing unit tests for your *Store* straightforward.
-For test examples, see the [commonTest](tart-core/src/commonTest/kotlin/io/yumemi/tart/core) directory in the `:tart-core` module.
+You can attach a `StoreRecorder` before the *Store* starts and use it to assert recorded state and event history.
+
+```kt
+@OptIn(ExperimentalTartApi::class)
+@Test
+fun counterStore_recordsStateHistory() = runTest {
+    val recorder = StoreRecorder<CounterState, CounterEvent>()
+    val store = CounterStore(...)
+
+    store.attachObserver(recorder)
+
+    store.dispatch(CounterAction.Increment)
+
+    assertEquals(
+        listOf(
+            CounterState(count = 0),
+            CounterState(count = 1),
+        ),
+        recorder.states,
+    )
+    assertEquals(
+        listOf(CounterEvent.Incremented(count = 1)),
+        recorder.events,
+    )
+}
+```
+
+If you need different recording behavior, you can also implement your own recorder by implementing `StoreObserver`.

--- a/README.md
+++ b/README.md
@@ -967,14 +967,14 @@ Also note that middleware execution order should not be relied on.
 
 ## Testing Store
 
-For most Store tests, use `attachRecorder()` to attach the default `StoreRecorder` and assert recorded state and event history.
+For most Store tests, use `createRecorder()` to create and attach the default `StoreRecorder`, then assert recorded state and event history.
 
 ```kt
 @Test
 fun counterStore_recordsStatesAndEvents() = runTest {
     // Given
     val store = CounterStore(...)
-    val recorder = store.attachRecorder()
+    val recorder = store.createRecorder()
 
     // When
     store.dispatchAndWait(CounterAction.Increment) // wait until the dispatched action completes

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin.code.style=official
 # MPP
 kotlin.mpp.enableCInteropCommonization=true
 # Work around Kotlin/Native cache build failures on iOS simulator test linking.
-kotlin.native.cacheKind=none
+kotlin.native.cacheKind.iosSimulatorArm64=none
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,8 @@ kotlin.code.style=official
 # kotlin.js.compiler=ir // Deprecated: IR compiler is the default and only option since Kotlin 2.0, and this project doesn't use JS target anyway
 # MPP
 kotlin.mpp.enableCInteropCommonization=true
+# Work around Kotlin/Native cache build failures on iOS simulator test linking.
+kotlin.native.cacheKind=none
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -8,10 +8,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.withRunningRecomposer
 import io.yumemi.tart.core.Action
 import io.yumemi.tart.core.Event
-import io.yumemi.tart.core.ExperimentalTartApi
 import io.yumemi.tart.core.State
 import io.yumemi.tart.core.Store
-import io.yumemi.tart.core.StoreObserver
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -267,20 +265,9 @@ private class TestStore(
         dispatchedActions += action
     }
 
-    @OptIn(ExperimentalTartApi::class)
-    override suspend fun dispatchAndWait(action: UiAction) {
-        dispatch(action)
-    }
-
     override fun collectState(state: (UiState) -> Unit) = Unit
 
     override fun collectEvent(event: (UiEvent) -> Unit) = Unit
-
-    override fun attachObserver(observer: StoreObserver<UiState, UiEvent>, notifyCurrentState: Boolean) {
-        if (notifyCurrentState) {
-            observer.onState(currentState)
-        }
-    }
 
     override fun dispose() {
         disposeCount++

--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.withRunningRecomposer
 import io.yumemi.tart.core.Action
 import io.yumemi.tart.core.Event
+import io.yumemi.tart.core.ExperimentalTartApi
 import io.yumemi.tart.core.State
 import io.yumemi.tart.core.Store
 import io.yumemi.tart.core.StoreObserver
@@ -264,6 +265,11 @@ private class TestStore(
 
     override fun dispatch(action: UiAction) {
         dispatchedActions += action
+    }
+
+    @OptIn(ExperimentalTartApi::class)
+    override suspend fun dispatchAndAwait(action: UiAction) {
+        dispatch(action)
     }
 
     override fun collectState(state: (UiState) -> Unit) = Unit

--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -10,6 +10,7 @@ import io.yumemi.tart.core.Action
 import io.yumemi.tart.core.Event
 import io.yumemi.tart.core.State
 import io.yumemi.tart.core.Store
+import io.yumemi.tart.core.StoreObserver
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -268,6 +269,12 @@ private class TestStore(
     override fun collectState(state: (UiState) -> Unit) = Unit
 
     override fun collectEvent(event: (UiEvent) -> Unit) = Unit
+
+    override fun attachObserver(observer: StoreObserver<UiState, UiEvent>, notifyCurrentState: Boolean) {
+        if (notifyCurrentState) {
+            observer.onState(currentState)
+        }
+    }
 
     override fun dispose() {
         disposeCount++

--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -268,7 +268,7 @@ private class TestStore(
     }
 
     @OptIn(ExperimentalTartApi::class)
-    override suspend fun dispatchAndAwait(action: UiAction) {
+    override suspend fun dispatchAndWait(action: UiAction) {
         dispatch(action)
     }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
  * Core interface of Tart that provides application state management.
  * It has features such as state updates, event emission, action dispatching, etc.
  */
-interface Store<S : State, A : Action, E : Event>: AutoCloseable {
+interface Store<S : State, A : Action, E : Event> : AutoCloseable {
 
     /**
      * StateFlow representing the current state. You can monitor state changes by subscribing to this.
@@ -46,9 +46,21 @@ interface Store<S : State, A : Action, E : Event>: AutoCloseable {
     fun collectEvent(event: (E) -> Unit)
 
     /**
+     * Attaches an observer before the store is started.
+     * This does not start the store.
+     *
+     * @param observer The observer to attach
+     * @param notifyCurrentState Whether to notify the observer with the current state immediately
+     * @throws IllegalStateException if the store is starting or has already started
+     */
+    fun attachObserver(observer: StoreObserver<S, E>, notifyCurrentState: Boolean = true)
+
+    /**
      * Releases the Store's resources.
      */
     fun dispose()
 
-    override fun close() { dispose() }
+    override fun close() {
+        dispose()
+    }
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -32,6 +32,17 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     fun dispatch(action: A)
 
     /**
+     * Dispatches an action and suspends until the dispatch work completes.
+     *
+     * This waits for the action handling performed as part of the dispatch itself.
+     * It does not wait for additional work launched from action/enter handlers.
+     *
+     * @param action The action to dispatch
+     */
+    @ExperimentalTartApi
+    suspend fun dispatchAndAwait(action: A)
+
+    /**
      * Collects state changes.
      *
      * @param state Callback called when the state changes

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -40,7 +40,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      * @param action The action to dispatch
      */
     @ExperimentalTartApi
-    suspend fun dispatchAndAwait(action: A)
+    suspend fun dispatchAndWait(action: A)
 
     /**
      * Collects state changes.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -32,17 +32,6 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     fun dispatch(action: A)
 
     /**
-     * Dispatches an action and suspends until the dispatch work completes.
-     *
-     * This waits for the action handling performed as part of the dispatch itself.
-     * It does not wait for additional work launched from action/enter handlers.
-     *
-     * @param action The action to dispatch
-     */
-    @ExperimentalTartApi
-    suspend fun dispatchAndWait(action: A)
-
-    /**
      * Collects state changes.
      *
      * @param state Callback called when the state changes
@@ -57,16 +46,6 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     fun collectEvent(event: (E) -> Unit)
 
     /**
-     * Attaches an observer before the store is started.
-     * This does not start the store.
-     *
-     * @param observer The observer to attach
-     * @param notifyCurrentState Whether to notify the observer with the current state immediately
-     * @throws IllegalStateException if the store is starting or has already started
-     */
-    fun attachObserver(observer: StoreObserver<S, E>, notifyCurrentState: Boolean = true)
-
-    /**
      * Releases the Store's resources.
      */
     fun dispose()
@@ -74,4 +53,39 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     override fun close() {
         dispose()
     }
+}
+
+/**
+ * Dispatches an action and suspends until the dispatch work completes.
+ *
+ * This waits for the action handling performed as part of the dispatch itself.
+ * It does not wait for additional work launched from action/enter handlers.
+ *
+ * This extension is available for Store instances created by Tart DSL.
+ *
+ * @param action The action to dispatch
+ * @throws IllegalStateException if the Store is not backed by Tart's internal implementation
+ */
+suspend fun <S : State, A : Action, E : Event> Store<S, A, E>.dispatchAndWait(action: A) {
+    requireStoreImpl().dispatchAndWaitInternal(action)
+}
+
+/**
+ * Attaches an observer before the store is started.
+ * This does not start the store.
+ *
+ * This extension is available for Store instances created by Tart DSL.
+ *
+ * @param observer The observer to attach
+ * @param notifyCurrentState Whether to notify the observer with the current state immediately
+ * @throws IllegalStateException if the store is starting or has already started
+ * @throws IllegalStateException if the Store is not backed by Tart's internal implementation
+ */
+fun <S : State, A : Action, E : Event> Store<S, A, E>.attachObserver(observer: StoreObserver<S, E>, notifyCurrentState: Boolean = true) {
+    requireStoreImpl().attachObserverInternal(observer, notifyCurrentState)
+}
+
+private fun <S : State, A : Action, E : Event> Store<S, A, E>.requireStoreImpl(): StoreImpl<S, A, E> {
+    return this as? StoreImpl<S, A, E>
+        ?: throw IllegalStateException("[Tart] This API is only supported for Store instances created by Tart DSL")
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -103,7 +103,16 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private var activeDispatchJob: Job? = null
 
     final override fun dispatch(action: A) {
-        dispatchScope.launch {
+        launchDispatch(action)
+    }
+
+    @OptIn(ExperimentalTartApi::class)
+    final override suspend fun dispatchAndAwait(action: A) {
+        launchDispatch(action).join()
+    }
+
+    private fun launchDispatch(action: A): Job {
+        return dispatchScope.launch {
             mutex.withLock {
                 val dispatchJob = coroutineContext[Job]
                 activeDispatchJob = dispatchJob

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -106,8 +106,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         launchDispatch(action)
     }
 
-    @OptIn(ExperimentalTartApi::class)
-    final override suspend fun dispatchAndWait(action: A) {
+    internal suspend fun dispatchAndWaitInternal(action: A) {
         launchDispatch(action).join()
     }
 
@@ -140,7 +139,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         }
     }
 
-    final override fun attachObserver(observer: StoreObserver<S, E>, notifyCurrentState: Boolean) {
+    internal fun attachObserverInternal(observer: StoreObserver<S, E>, notifyCurrentState: Boolean) {
         check(mutex.tryLock()) { "[Tart] Failed to attach observer because the Store is starting or already started" }
         try {
             check(!isInitialized) { "[Tart] Observer must be attached before the Store starts" }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -98,6 +98,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private val stateScopes = mutableMapOf<KClass<out S>, CoroutineScope>()
 
+    private val observers = mutableListOf<StoreObserver<S, E>>()
+
     private var activeDispatchJob: Job? = null
 
     final override fun dispatch(action: A) {
@@ -126,6 +128,19 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     final override fun collectEvent(event: (E) -> Unit) {
         coroutineScope.launch((Dispatchers.Unconfined)) {
             this@StoreImpl.event.collect { event(it) }
+        }
+    }
+
+    final override fun attachObserver(observer: StoreObserver<S, E>, notifyCurrentState: Boolean) {
+        check(mutex.tryLock()) { "[Tart] Failed to attach observer because the Store is starting or already started" }
+        try {
+            check(!isInitialized) { "[Tart] Observer must be attached before the Store starts" }
+            if (notifyCurrentState) {
+                observer.onState(currentState)
+            }
+            observers.add(observer)
+        } finally {
+            mutex.unlock()
         }
     }
 
@@ -502,6 +517,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             rethrowIfFatal(t)
             throw InternalError(t)
         }
+        notifyStateRecorded(nextState)
         processMiddleware { afterStateChange(nextState, state) }
     }
 
@@ -537,6 +553,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private suspend fun processEventEmit(state: S, event: E) {
         processMiddleware { beforeEventEmit(state, event) }
         _event.emit(event)
+        notifyEventRecorded(event)
         processMiddleware { afterEventEmit(state, event) }
     }
 
@@ -564,6 +581,28 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         } catch (t: Throwable) {
             rethrowIfFatal(t)
             throw InternalError(t)
+        }
+    }
+
+    private fun notifyStateRecorded(state: S) {
+        observers.forEach { observer ->
+            try {
+                observer.onState(state)
+            } catch (t: Throwable) {
+                rethrowIfFatal(t)
+                throw InternalError(t)
+            }
+        }
+    }
+
+    private fun notifyEventRecorded(event: E) {
+        observers.forEach { observer ->
+            try {
+                observer.onEvent(event)
+            } catch (t: Throwable) {
+                rethrowIfFatal(t)
+                throw InternalError(t)
+            }
         }
     }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -107,7 +107,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     }
 
     @OptIn(ExperimentalTartApi::class)
-    final override suspend fun dispatchAndAwait(action: A) {
+    final override suspend fun dispatchAndWait(action: A) {
         launchDispatch(action).join()
     }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
@@ -1,7 +1,10 @@
 package io.yumemi.tart.core
 
 /**
- * Observer for Store state snapshots and emitted events.
+ * Extension point for observing Store state snapshots and emitted events.
+ *
+ * For most test cases, prefer [StoreRecorder] or [Store.attachRecorder].
+ * Implement this interface when you need custom recording or observation behavior.
  */
 interface StoreObserver<S : State, E : Event> {
     /**
@@ -36,7 +39,7 @@ fun <S : State, E : Event> StoreObserver(
 }
 
 /**
- * Recorder that keeps Store state snapshots and emitted events in memory.
+ * Default in-memory [StoreObserver] implementation for tests.
  *
  * This API currently lives in `:tart-core`, but it is intended primarily for testing support.
  * It may be moved to a dedicated testing module in the future.
@@ -71,4 +74,21 @@ class StoreRecorder<S : State, E : Event> : StoreObserver<S, E> {
     override fun onEvent(event: E) {
         recordedEvents.add(event)
     }
+}
+
+/**
+ * Creates and attaches the default [StoreRecorder] for this Store.
+ *
+ * Prefer this in tests unless you need a custom [StoreObserver] implementation.
+ *
+ * @param notifyCurrentState Whether to notify the recorder with the current state immediately
+ * @return The attached [StoreRecorder]
+ */
+@ExperimentalTartApi
+fun <S : State, A : Action, E : Event> Store<S, A, E>.attachRecorder(
+    notifyCurrentState: Boolean = true,
+): StoreRecorder<S, E> {
+    val recorder = StoreRecorder<S, E>()
+    attachObserver(recorder, notifyCurrentState)
+    return recorder
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
@@ -3,7 +3,7 @@ package io.yumemi.tart.core
 /**
  * Extension point for observing Store state snapshots and emitted events.
  *
- * For most test cases, prefer [StoreRecorder] or [Store.attachRecorder].
+ * For most test cases, prefer [StoreRecorder] or [Store.createRecorder].
  * Implement this interface when you need custom recording or observation behavior.
  */
 interface StoreObserver<S : State, E : Event> {
@@ -85,7 +85,7 @@ class StoreRecorder<S : State, E : Event> : StoreObserver<S, E> {
  * @return The attached [StoreRecorder]
  */
 @ExperimentalTartApi
-fun <S : State, A : Action, E : Event> Store<S, A, E>.attachRecorder(
+fun <S : State, A : Action, E : Event> Store<S, A, E>.createRecorder(
     notifyCurrentState: Boolean = true,
 ): StoreRecorder<S, E> {
     val recorder = StoreRecorder<S, E>()

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreObserver.kt
@@ -1,0 +1,74 @@
+package io.yumemi.tart.core
+
+/**
+ * Observer for Store state snapshots and emitted events.
+ */
+interface StoreObserver<S : State, E : Event> {
+    /**
+     * Called when a state snapshot is observed.
+     */
+    fun onState(state: S)
+
+    /**
+     * Called when an event emission is observed.
+     */
+    fun onEvent(event: E)
+}
+
+/**
+ * Factory function to easily create a StoreObserver instance.
+ *
+ * @param onState Callback invoked when a state snapshot is observed
+ * @param onEvent Callback invoked when an event emission is observed
+ * @return A new StoreObserver instance
+ */
+fun <S : State, E : Event> StoreObserver(
+    onState: (S) -> Unit = {},
+    onEvent: (E) -> Unit = {},
+): StoreObserver<S, E> = object : StoreObserver<S, E> {
+    override fun onState(state: S) {
+        onState.invoke(state)
+    }
+
+    override fun onEvent(event: E) {
+        onEvent.invoke(event)
+    }
+}
+
+/**
+ * Recorder that keeps Store state snapshots and emitted events in memory.
+ *
+ * This API currently lives in `:tart-core`, but it is intended primarily for testing support.
+ * It may be moved to a dedicated testing module in the future.
+ */
+@ExperimentalTartApi
+class StoreRecorder<S : State, E : Event> : StoreObserver<S, E> {
+    private val recordedStates = mutableListOf<S>()
+    private val recordedEvents = mutableListOf<E>()
+
+    /**
+     * State snapshots recorded for this Store.
+     */
+    val states: List<S> = recordedStates
+
+    /**
+     * Events recorded for this Store.
+     */
+    val events: List<E> = recordedEvents
+
+    /**
+     * Clears all recorded history.
+     */
+    fun clear() {
+        recordedStates.clear()
+        recordedEvents.clear()
+    }
+
+    override fun onState(state: S) {
+        recordedStates.add(state)
+    }
+
+    override fun onEvent(event: E) {
+        recordedEvents.add(event)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -102,7 +102,7 @@ class StoreBaseTest {
     }
 
     @Test
-    fun tartStore_dispatchAndAwait_shouldSuspendUntilActionHandled() = runTest(testDispatcher) {
+    fun tartStore_dispatchAndWait_shouldSuspendUntilActionHandled() = runTest(testDispatcher) {
         val gate = CompletableDeferred<Unit>()
         val store: Store<AppState, AppAction, AppEvent> = Store(AppState.Loading) {
             coroutineContext(Dispatchers.Unconfined)
@@ -121,7 +121,7 @@ class StoreBaseTest {
 
         val dispatchJob = launch {
             @OptIn(ExperimentalTartApi::class)
-            store.dispatchAndAwait(AppAction.Increment)
+            store.dispatchAndWait(AppAction.Increment)
         }
 
         assertFalse(dispatchJob.isCompleted)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -120,7 +120,6 @@ class StoreBaseTest {
         }
 
         val dispatchJob = launch {
-            @OptIn(ExperimentalTartApi::class)
             store.dispatchAndWait(AppAction.Increment)
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -1,11 +1,13 @@
 package io.yumemi.tart.core
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
@@ -95,6 +97,38 @@ class StoreBaseTest {
         store.dispatch(AppAction.Increment)
         store.dispatch(AppAction.Increment)
         store.dispatch(AppAction.Decrement)
+
+        assertEquals(AppState.Main(1), store.currentState)
+    }
+
+    @Test
+    fun tartStore_dispatchAndAwait_shouldSuspendUntilActionHandled() = runTest(testDispatcher) {
+        val gate = CompletableDeferred<Unit>()
+        val store: Store<AppState, AppAction, AppEvent> = Store(AppState.Loading) {
+            coroutineContext(Dispatchers.Unconfined)
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Main(count = 0))
+                }
+            }
+            state<AppState.Main> {
+                action<AppAction.Increment> {
+                    gate.await()
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+
+        val dispatchJob = launch {
+            @OptIn(ExperimentalTartApi::class)
+            store.dispatchAndAwait(AppAction.Increment)
+        }
+
+        assertFalse(dispatchJob.isCompleted)
+        assertEquals(AppState.Main(0), store.currentState)
+
+        gate.complete(Unit)
+        dispatchJob.join()
 
         assertEquals(AppState.Main(1), store.currentState)
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
@@ -1,0 +1,311 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreObserverTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    sealed interface AppState : State {
+        data object Loading : AppState
+        data class Main(val count: Int) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object EmitEvent : AppAction
+    }
+
+    sealed interface AppEvent : Event {
+        data class CountUpdated(val count: Int) : AppEvent
+    }
+
+    @Test
+    fun attachObserver_recordsRestoredCurrentStateWithoutStartingStore() = runTest(testDispatcher) {
+        var started = false
+        val store = createTestStore(
+            stateSaver = StateSaver(
+                save = {},
+                restore = { AppState.Main(count = 5) },
+            ),
+            onStart = { started = true },
+        )
+        val history = ObservationHistory<AppState, AppEvent>()
+        val observer = history.toObserver()
+
+        store.attachObserver(observer)
+
+        assertFalse(started)
+        assertEquals(listOf<AppState>(AppState.Main(count = 5)), history.stateHistory)
+        assertTrue(history.eventHistory.isEmpty())
+    }
+
+    @Test
+    fun attachObserver_recordsStateChangesAndEvents() = runTest(testDispatcher) {
+        val store = createTestStore()
+        val history = ObservationHistory<AppState, AppEvent>()
+        val observer = history.toObserver()
+
+        store.attachObserver(observer)
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.EmitEvent)
+
+        assertEquals(
+            listOf(
+                AppState.Loading,
+                AppState.Main(count = 0),
+                AppState.Main(count = 1),
+            ),
+            history.stateHistory,
+        )
+        assertEquals(listOf<AppEvent>(AppEvent.CountUpdated(count = 1)), history.eventHistory)
+    }
+
+    @Test
+    fun attachObserver_canBeCalledMultipleTimesBeforeStart() = runTest(testDispatcher) {
+        val store = createTestStore()
+        val firstHistory = ObservationHistory<AppState, AppEvent>()
+        val secondHistory = ObservationHistory<AppState, AppEvent>()
+
+        store.attachObserver(firstHistory.toObserver())
+        store.attachObserver(secondHistory.toObserver())
+        store.dispatch(AppAction.EmitEvent)
+
+        assertEquals(firstHistory.stateHistory, secondHistory.stateHistory)
+        assertEquals(firstHistory.eventHistory, secondHistory.eventHistory)
+    }
+
+    @Test
+    fun attachObserver_isAllowedAfterCollectingEventsBeforeStart() = runTest(testDispatcher) {
+        val store = createTestStore()
+        val history = ObservationHistory<AppState, AppEvent>()
+
+        store.collectEvent { }
+        store.attachObserver(history.toObserver())
+        store.dispatch(AppAction.EmitEvent)
+
+        assertEquals(
+            listOf(
+                AppState.Loading,
+                AppState.Main(count = 0),
+            ),
+            history.stateHistory,
+        )
+        assertEquals(listOf<AppEvent>(AppEvent.CountUpdated(count = 0)), history.eventHistory)
+    }
+
+    @Test
+    fun attachObserver_throwsAfterStoreStart() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.Increment)
+
+        try {
+            store.attachObserver(StoreObserver())
+            fail("Expected attachObserver to fail after store start")
+        } catch (t: Throwable) {
+            assertIs<IllegalStateException>(t)
+        }
+    }
+
+    @Test
+    fun attachObserver_canSkipInitialCurrentStateSnapshot() = runTest(testDispatcher) {
+        val store = createTestStore()
+        val history = ObservationHistory<AppState, AppEvent>()
+
+        store.attachObserver(history.toObserver(), notifyCurrentState = false)
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(
+            listOf<AppState>(
+                AppState.Main(count = 0),
+                AppState.Main(count = 1),
+            ),
+            history.stateHistory,
+        )
+        assertTrue(history.eventHistory.isEmpty())
+    }
+
+    @Test
+    fun attachObserver_initialStateObserverException_isRethrownAndObserverIsNotRegistered() = runTest(testDispatcher) {
+        var observerInvocationCount = 0
+        val store = createTestStore(
+            stateSaver = StateSaver(
+                save = {},
+                restore = { AppState.Main(count = 5) },
+            ),
+        )
+        val observer = StoreObserver<AppState, AppEvent>(
+            onState = {
+                observerInvocationCount++
+                throw IllegalStateException("observer failed during attach")
+            },
+        )
+
+        try {
+            store.attachObserver(observer)
+            fail("Expected attachObserver to rethrow observer exception")
+        } catch (t: Throwable) {
+            assertIs<IllegalStateException>(t)
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(1, observerInvocationCount)
+        assertEquals(AppState.Main(count = 6), store.currentState)
+    }
+
+    @Test
+    fun observerStateException_isHandledWithoutUsingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createTestStore(
+            exceptionHandler = ExceptionHandler { error ->
+                handledException = error
+            },
+            errorStateOnException = AppState.Main(count = -1),
+        )
+        val observer = StoreObserver<AppState, AppEvent>(
+            onState = { state ->
+                if (state == AppState.Main(count = 1)) {
+                    throw IllegalArgumentException("observer state failed")
+                }
+            },
+        )
+
+        store.attachObserver(observer)
+        store.dispatch(AppAction.Increment)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Main(count = 1), store.currentState)
+        assertIs<IllegalArgumentException>(handledException)
+    }
+
+    @Test
+    fun observerEventException_isHandledWithoutUsingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createTestStore(
+            exceptionHandler = ExceptionHandler { error ->
+                handledException = error
+            },
+            errorStateOnException = AppState.Main(count = -1),
+        )
+        val observer = StoreObserver<AppState, AppEvent>(
+            onEvent = {
+                throw IllegalArgumentException("observer event failed")
+            },
+        )
+
+        store.attachObserver(observer)
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.EmitEvent)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Main(count = 1), store.currentState)
+        assertIs<IllegalArgumentException>(handledException)
+    }
+
+    private fun createTestStore(
+        stateSaver: StateSaver<AppState> = StateSaver.Noop(),
+        onStart: (() -> Unit)? = null,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+        errorStateOnException: AppState? = null,
+    ): Store<AppState, AppAction, AppEvent> {
+        return Store(AppState.Loading) {
+            coroutineContext(Dispatchers.Unconfined)
+            stateSaver(stateSaver)
+            exceptionHandler(exceptionHandler)
+            middleware(
+                Middleware(
+                    onStart = {
+                        onStart?.invoke()
+                    },
+                ),
+            )
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Main(count = 0))
+                }
+            }
+
+            state<AppState.Main> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+                action<AppAction.EmitEvent> {
+                    event(AppEvent.CountUpdated(count = state.count))
+                }
+            }
+
+            if (errorStateOnException != null) {
+                state<AppState> {
+                    error<Throwable> {
+                        nextState(errorStateOnException)
+                    }
+                }
+            }
+        }
+    }
+
+    private class ObservationHistory<S : State, E : Event> {
+        val stateHistory = mutableListOf<S>()
+        val eventHistory = mutableListOf<E>()
+
+        fun toObserver(): StoreObserver<S, E> = StoreObserver(
+            onState = { state ->
+                stateHistory.add(state)
+            },
+            onEvent = { event ->
+                eventHistory.add(event)
+            },
+        )
+    }
+
+    @Test
+    fun storeObserverFactory_canCreateStateOnlyObserver() = runTest(testDispatcher) {
+        val observedStates = mutableListOf<AppState>()
+        val observer = StoreObserver<AppState, AppEvent>(
+            onState = { state ->
+                observedStates.add(state)
+            },
+        )
+
+        observer.onState(AppState.Loading)
+
+        assertEquals(listOf<AppState>(AppState.Loading), observedStates)
+    }
+
+    @Test
+    fun storeObserverFactory_canCreateEventOnlyObserver() = runTest(testDispatcher) {
+        val observedEvents = mutableListOf<AppEvent>()
+        val observer = StoreObserver<AppState, AppEvent>(
+            onEvent = { event ->
+                observedEvents.add(event)
+            },
+        )
+
+        observer.onEvent(AppEvent.CountUpdated(count = 1))
+
+        assertEquals(listOf<AppEvent>(AppEvent.CountUpdated(count = 1)), observedEvents)
+    }
+
+    @Test
+    fun storeObserverFactory_defaultsToNoopCallbacks() = runTest(testDispatcher) {
+        val observer = StoreObserver<AppState, AppEvent>()
+
+        observer.onState(AppState.Loading)
+        observer.onEvent(AppEvent.CountUpdated(count = 1))
+
+        assertTrue(true)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
@@ -1,0 +1,60 @@
+package io.yumemi.tart.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTartApi::class)
+class StoreRecorderTest {
+
+    sealed interface AppState : State {
+        data object Loading : AppState
+        data class Main(val count: Int) : AppState
+    }
+
+    sealed interface AppEvent : Event {
+        data class CountUpdated(val count: Int) : AppEvent
+    }
+
+    @Test
+    fun storeRecorder_recordsStateHistoryAndEventHistory() {
+        val recorder = StoreRecorder<AppState, AppEvent>()
+
+        recorder.onState(AppState.Loading)
+        recorder.onState(AppState.Main(count = 0))
+        recorder.onEvent(AppEvent.CountUpdated(count = 0))
+        recorder.onState(AppState.Main(count = 1))
+        recorder.onEvent(AppEvent.CountUpdated(count = 1))
+
+        assertEquals(
+            listOf(
+                AppState.Loading,
+                AppState.Main(count = 0),
+                AppState.Main(count = 1),
+            ),
+            recorder.states,
+        )
+        assertEquals(
+            listOf(
+                AppEvent.CountUpdated(count = 0),
+                AppEvent.CountUpdated(count = 1),
+            ),
+            recorder.events,
+        )
+    }
+
+    @Test
+    fun recorder_clear_resetsRecordedHistory() {
+        val recorder = StoreRecorder<AppState, AppEvent>()
+
+        recorder.onState(AppState.Main(count = 9))
+        recorder.onEvent(AppEvent.CountUpdated(count = 9))
+
+        assertTrue(recorder.states.isNotEmpty())
+        assertTrue(recorder.events.isNotEmpty())
+        recorder.clear()
+
+        assertTrue(recorder.states.isEmpty())
+        assertTrue(recorder.events.isEmpty())
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
@@ -89,10 +89,10 @@ class StoreRecorderTest {
     }
 
     @Test
-    fun attachRecorder_createsAndAttachesRecorder() = runTest(testDispatcher) {
+    fun createRecorder_createsAndAttachesRecorder() = runTest(testDispatcher) {
         val store = createTestStore()
 
-        val recorder = store.attachRecorder()
+        val recorder = store.createRecorder()
         store.dispatchAndWait(AppAction.Increment)
         store.dispatchAndWait(AppAction.EmitEvent)
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreRecorderTest.kt
@@ -1,19 +1,49 @@
 package io.yumemi.tart.core
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalTartApi::class)
+@OptIn(ExperimentalTartApi::class, ExperimentalCoroutinesApi::class)
 class StoreRecorderTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     sealed interface AppState : State {
         data object Loading : AppState
         data class Main(val count: Int) : AppState
     }
 
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object EmitEvent : AppAction
+    }
+
     sealed interface AppEvent : Event {
         data class CountUpdated(val count: Int) : AppEvent
+    }
+
+    private fun createTestStore(): Store<AppState, AppAction, AppEvent> {
+        return Store(AppState.Loading) {
+            coroutineContext(Dispatchers.Unconfined)
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Main(count = 0))
+                }
+            }
+            state<AppState.Main> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+                action<AppAction.EmitEvent> {
+                    event(AppEvent.CountUpdated(state.count))
+                }
+            }
+        }
     }
 
     @Test
@@ -56,5 +86,29 @@ class StoreRecorderTest {
 
         assertTrue(recorder.states.isEmpty())
         assertTrue(recorder.events.isEmpty())
+    }
+
+    @Test
+    fun attachRecorder_createsAndAttachesRecorder() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        val recorder = store.attachRecorder()
+        store.dispatchAndWait(AppAction.Increment)
+        store.dispatchAndWait(AppAction.EmitEvent)
+
+        assertEquals(
+            listOf(
+                AppState.Loading,
+                AppState.Main(count = 0),
+                AppState.Main(count = 1),
+            ),
+            recorder.states,
+        )
+        assertEquals(
+            listOf(
+                AppEvent.CountUpdated(count = 1),
+            ),
+            recorder.events,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add `StoreObserver` plus the experimental `StoreRecorder` test utility to `tart-core`
- add observer attachment support on `Store`, with `notifyCurrentState` behavior and coverage for observer error handling
- add the experimental `dispatchAndWait()` helper for waiting on a dispatched action in tests
- add `attachRecorder()` as the default convenience for recorder-based Store tests and update the README/testing guidance
- disable Kotlin/Native compiler caches in `gradle.properties` to avoid iOS simulator test link failures in this branch's current toolchain

## Verification
- `./gradlew :tart-core:jvmTest :tart-compose:jvmTest`
- `./gradlew :tart-core:iosSimulatorArm64Test :tart-compose:iosSimulatorArm64Test`