### PR TITLE
Add middleware execution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ By default, Tart clears already queued actions when the store exits the current 
 To keep queued actions across state exits, set `pendingActionPolicy(PendingActionPolicy.KEEP)`.
 
 ```kt
-val store = Store<MyState, MyAction, MyEvent>(MyState.Initial) {
+val store: Store<CounterState, CounterAction, CounterEvent> = Store {
     // ...
 
     pendingActionPolicy(PendingActionPolicy.KEEP)
@@ -823,7 +823,18 @@ Note that *State* is read-only in Middleware.
 
 You can also create a `Middleware` instance with the `Middleware()` factory function.
 
-Middleware methods are suspending functions. The *Store* waits for a method to complete before proceeding.
+Middleware methods are suspending functions. The *Store* waits for middleware processing to complete before proceeding.
+When multiple middleware instances are registered, Tart invokes them concurrently by default.
+If middleware must run one by one in registration order, set `middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)`.
+
+```kt
+val store: Store<CounterState, CounterAction, CounterEvent> = Store {
+    // ...
+
+    middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)
+}
+```
+
 Because a long-running method can block the *Store*, run heavy work in a separate CoroutineScope.
 
 In the next section, we introduce built-in Middleware.
@@ -948,6 +959,7 @@ Inside `overrides` block, you can use these APIs:
 - `middleware(...)`
 - `clearMiddlewares()`
 - `replaceMiddlewares(...)`
+- `middlewareExecutionPolicy(...)`
 
 Typical uses are:
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareExecutionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareExecutionPolicy.kt
@@ -1,0 +1,16 @@
+package io.yumemi.tart.core
+
+/**
+ * Controls how the Store invokes middleware when multiple middleware instances are registered.
+ */
+enum class MiddlewareExecutionPolicy {
+    /**
+     * Invokes middleware methods concurrently and waits until all of them complete.
+     */
+    CONCURRENT,
+
+    /**
+     * Invokes middleware methods one by one in registration order.
+     */
+    IN_REGISTRATION_ORDER,
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -14,6 +14,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
     private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.CLEAR_ON_STATE_EXIT
+    private var storeMiddlewareExecutionPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.CONCURRENT
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**
@@ -59,6 +60,15 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
      */
     fun pendingActionPolicy(policy: PendingActionPolicy) {
         storePendingActionPolicy = policy
+    }
+
+    /**
+     * Sets how the store invokes middleware when multiple middleware instances are registered.
+     *
+     * @param policy The middleware execution policy to use
+     */
+    fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
+        storeMiddlewareExecutionPolicy = policy
     }
 
     /**
@@ -356,6 +366,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val stateSaver: StateSaver<S> = storeStateSaver
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
             override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
+            override val middlewareExecutionPolicy: MiddlewareExecutionPolicy = storeMiddlewareExecutionPolicy
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
             override val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
@@ -405,6 +416,13 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         operations.add { exceptionHandler(exceptionHandler) }
+    }
+
+    /**
+     * Overrides how the store invokes middleware when multiple middleware instances are registered.
+     */
+    fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
+        operations.add { middlewareExecutionPolicy(policy) }
     }
 
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -71,6 +71,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val pendingActionPolicy: PendingActionPolicy
 
+    protected abstract val middlewareExecutionPolicy: MiddlewareExecutionPolicy
+
     protected abstract val middlewares: List<Middleware<S, A, E>>
 
     protected abstract val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit
@@ -582,9 +584,14 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun processMiddleware(block: suspend Middleware<S, A, E>.() -> Unit) {
         try {
-            coroutineScope {
-                middlewares.map {
-                    launch { block(it) }
+            when (middlewareExecutionPolicy) {
+                MiddlewareExecutionPolicy.CONCURRENT -> coroutineScope {
+                    middlewares.forEach { middleware ->
+                        launch { middleware.block() }
+                    }
+                }
+                MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER -> middlewares.forEach { middleware ->
+                    middleware.block()
                 }
             }
         } catch (t: Throwable) {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExecutionPolicyTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExecutionPolicyTest.kt
@@ -1,0 +1,169 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreMiddlewareExecutionPolicyTest {
+
+    data class AppState(val count: Int = 0) : State
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+    }
+
+    private fun createStore(
+        testDispatcher: TestDispatcher,
+        records: MutableList<String>,
+        firstMiddlewareStarted: CompletableDeferred<Unit>,
+        secondMiddlewareStarted: CompletableDeferred<Unit>,
+        firstMiddlewareCanFinish: CompletableDeferred<Unit>,
+        setupPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.CONCURRENT,
+        overrides: Overrides<AppState, AppAction, Nothing> = {},
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(
+            initialState = AppState(),
+            overrides = overrides,
+        ) {
+            coroutineContext(testDispatcher)
+            middlewareExecutionPolicy(setupPolicy)
+
+            middleware(
+                Middleware(
+                    beforeActionDispatch = { _, _ ->
+                        records += "first:start"
+                        firstMiddlewareStarted.complete(Unit)
+                        firstMiddlewareCanFinish.await()
+                        records += "first:end"
+                    },
+                ),
+                Middleware(
+                    beforeActionDispatch = { _, _ ->
+                        records += "second:start"
+                        secondMiddlewareStarted.complete(Unit)
+                        records += "second:end"
+                    },
+                ),
+            )
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun concurrent_isDefaultAndAllowsOtherMiddlewareToRunWhileOneIsSuspended() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstMiddlewareStarted = CompletableDeferred<Unit>()
+        val secondMiddlewareStarted = CompletableDeferred<Unit>()
+        val firstMiddlewareCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstMiddlewareStarted = firstMiddlewareStarted,
+            secondMiddlewareStarted = secondMiddlewareStarted,
+            firstMiddlewareCanFinish = firstMiddlewareCanFinish,
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstMiddlewareStarted.isCompleted)
+        assertTrue(secondMiddlewareStarted.isCompleted)
+        assertEquals(
+            listOf("first:start", "second:start", "second:end"),
+            records,
+        )
+
+        firstMiddlewareCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "second:start", "second:end", "first:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+
+    @Test
+    fun inRegistrationOrder_waitsForPreviousMiddlewareToFinishBeforeStartingNextOne() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstMiddlewareStarted = CompletableDeferred<Unit>()
+        val secondMiddlewareStarted = CompletableDeferred<Unit>()
+        val firstMiddlewareCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstMiddlewareStarted = firstMiddlewareStarted,
+            secondMiddlewareStarted = secondMiddlewareStarted,
+            firstMiddlewareCanFinish = firstMiddlewareCanFinish,
+            setupPolicy = MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER,
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstMiddlewareStarted.isCompleted)
+        assertFalse(secondMiddlewareStarted.isCompleted)
+        assertEquals(listOf("first:start"), records)
+
+        firstMiddlewareCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "first:end", "second:start", "second:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+
+    @Test
+    fun overrides_canReplaceMiddlewareExecutionPolicy() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstMiddlewareStarted = CompletableDeferred<Unit>()
+        val secondMiddlewareStarted = CompletableDeferred<Unit>()
+        val firstMiddlewareCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstMiddlewareStarted = firstMiddlewareStarted,
+            secondMiddlewareStarted = secondMiddlewareStarted,
+            firstMiddlewareCanFinish = firstMiddlewareCanFinish,
+            setupPolicy = MiddlewareExecutionPolicy.CONCURRENT,
+            overrides = {
+                middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)
+            },
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstMiddlewareStarted.isCompleted)
+        assertFalse(secondMiddlewareStarted.isCompleted)
+        assertEquals(listOf("first:start"), records)
+
+        firstMiddlewareCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "first:end", "second:start", "second:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+}


### PR DESCRIPTION
## Summary
- add MiddlewareExecutionPolicy to control how multiple middleware instances are invoked
- expose middlewareExecutionPolicy(...) from both StoreBuilder and StoreOverridesBuilder
- update StoreImpl to support concurrent execution and registration-order execution
- add JVM tests covering the default behavior, the ordered behavior, and overrides
- document the new configuration in the README

## Why
Tart currently invokes multiple middleware hooks concurrently. Some apps need deterministic execution in registration order, while others prefer the current behavior for throughput. This change makes that behavior explicit and configurable without changing the default.

## Validation
- ./gradlew :tart-core:jvmTest

## Related
- Related to #175