### PR TITLE
Support pending action policy overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It keeps surrounding helper layers intentionally small, so dependencies and feat
 - [Middleware](#middleware)
   - [Logging](#logging)
   - [Message](#message)
-- [Overrides](#overrides)
+- [Store Configuration Overrides](#store-configuration-overrides)
 - [Project-specific AppStore Wrapper](#project-specific-appstore-wrapper)
 - [Testing Store](#testing-store)
 
@@ -911,7 +911,7 @@ val mainStore: Store<MainState, MainAction, MainEvent> = Store {
 ```
 </details>
 
-## Overrides
+## Store Configuration Overrides
 
 `Store{}` DSL accepts an `overrides` block that is applied after the main setup block.
 Use it when you want to override *Store* configuration.
@@ -948,6 +948,7 @@ Inside `overrides` block, you can use these APIs:
 - `middleware(...)`
 - `clearMiddlewares()`
 - `replaceMiddlewares(...)`
+- `pendingActionPolicy(...)`
 
 Typical uses are:
 
@@ -1004,7 +1005,7 @@ val testStore = CounterStore(
 
 ## Testing Store
 
-Add `:tart-test` to your test source set to use Tart's test helpers such as `createRecorder()`, `dispatchAndWait()`, and `attachObserver()`.
+Add `:tart-test` to your test source set to use Tart's test helpers such as `createRecorder()` and `dispatchAndWait()`.
 
 ```kt
 commonTestImplementation("io.yumemi.tart:tart-test:<latest-release>")
@@ -1037,5 +1038,5 @@ fun counterStore_recordsStatesAndEvents() = runTest {
 }
 ```
 
-If you need custom recording behavior, you can implement your own recorder by implementing `StoreObserver`.
+If you need custom recording behavior, implement your own `StoreObserver` and attach it with `attachObserver()`.
 If your `action {}` or `enter {}` logic launches additional coroutines with `launch {}`, or if you need virtual time control, use test dispatcher and scheduler control separately.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -373,7 +373,7 @@ typealias Setup<S, A, E> = StoreBuilder<S, A, E>.() -> Unit
 /**
  * Store overrides block applied after the main Store setup.
  * This block is limited to non-state configuration such as coroutine context,
- * persistence, exception handling, and middleware.
+ * persistence, exception handling, pending action policy, and middleware.
  */
 typealias Overrides<S, A, E> = StoreOverridesBuilder<S, A, E>.() -> Unit
 
@@ -405,6 +405,13 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         operations.add { exceptionHandler(exceptionHandler) }
+    }
+
+    /**
+     * Overrides how queued actions are handled when the store exits the current state.
+     */
+    fun pendingActionPolicy(policy: PendingActionPolicy) {
+        operations.add { pendingActionPolicy(policy) }
     }
 
     /**

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
@@ -1,16 +1,33 @@
 package io.yumemi.tart.core
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class StoreOverridesTest {
 
     data class AppState(val count: Int) : State
 
     sealed interface AppAction : Action {
         data object Increment : AppAction
+    }
+
+    sealed interface PendingPolicyState : State {
+        data object Initial : PendingPolicyState
+        data class Active(val value: Int = 0) : PendingPolicyState
+    }
+
+    sealed interface PendingPolicyAction : Action {
+        data object EnterActiveAfterDelay : PendingPolicyAction
+        data object Increment : PendingPolicyAction
     }
 
     private class RecordingStateSaver(
@@ -160,5 +177,42 @@ class StoreOverridesTest {
             listOf("override1", "override2", "setup1", "setup2"),
             middlewareRecords.sorted(),
         )
+    }
+
+    @Test
+    fun pendingActionPolicyInOverrides_shouldOverrideSetupConfiguration() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val store = Store<PendingPolicyState, PendingPolicyAction, Nothing>(
+            initialState = PendingPolicyState.Initial,
+            overrides = {
+                pendingActionPolicy(PendingActionPolicy.KEEP)
+            },
+        ) {
+            coroutineContext(testDispatcher)
+            pendingActionPolicy(PendingActionPolicy.CLEAR_ON_STATE_EXIT)
+
+            state<PendingPolicyState.Initial> {
+                action<PendingPolicyAction.EnterActiveAfterDelay>(testDispatcher) {
+                    delay(100)
+                    nextState(PendingPolicyState.Active())
+                }
+            }
+
+            state<PendingPolicyState.Active> {
+                action<PendingPolicyAction.Increment>(testDispatcher) {
+                    nextState(state.copy(value = state.value + 1))
+                }
+            }
+        }
+
+        store.dispatch(PendingPolicyAction.EnterActiveAfterDelay)
+        runCurrent()
+
+        store.dispatch(PendingPolicyAction.Increment)
+        store.dispatch(PendingPolicyAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(PendingPolicyState.Active(value = 2), store.currentState)
     }
 }


### PR DESCRIPTION
## Summary
- add `pendingActionPolicy(...)` to `StoreOverridesBuilder` so overrides can replace the pending action policy after the main store setup
- add JVM test coverage for override precedence when the setup and overrides configure different pending action policies
- rename the README Overrides section to Store Configuration Overrides and clarify the `attachObserver()` mention in the Testing Store section

## Why
- align pending action policy with the other store configuration values that can already be overridden through `overrides {}`
- make the README wording clearer about what the overrides block is for and where custom observer attachment belongs

## Verification
- `./gradlew :tart-core:jvmTest`