### PR TITLE
Add middleware execution policy note

### DIFF
--- a/doc/internal/2026-04-23-middleware-execution-policy.md
+++ b/doc/internal/2026-04-23-middleware-execution-policy.md
@@ -1,0 +1,33 @@
+# Middleware 実行ポリシーは並行を標準にする
+
+- 状態: 決定済み
+- 更新日: 2026-04-23
+- 関連: [MiddlewareExecutionPolicy.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareExecutionPolicy.kt)、[StoreBuilder.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt)、[StoreImpl.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt)、[README.md](../../README.md)
+
+## 背景
+
+Tart では複数の `Middleware` を登録できる。
+このとき、各 lifecycle hook を registration order で直列に流すか、並行に流すかは仕様として明確にしておきたい。
+
+`Middleware` は logging、message bridge、監視、補助的な dispatch など、Store の本体ロジックから関心事を分離するための拡張ポイントとして使う。
+そのため、複数の `Middleware` が互いの副作用や実行順に依存し始めると、設計意図から外れやすい。
+
+## 結論
+
+`MiddlewareExecutionPolicy` のデフォルトは `CONCURRENT` とする。
+
+複数の `Middleware` を使う場合でも、それぞれは原則として互いに疎結合であるべきで、他の `Middleware` の完了や副作用を前提に設計しない、という考え方を基本にする。
+ただし `IN_REGISTRATION_ORDER` も正式な option として残す。
+
+## 補足
+
+- 並行実行を標準にする理由は performance だけではない。より重要なのは、`Middleware` 同士が関与し合う設計を後押ししないことにある。
+- もし `Middleware A` が `Middleware B` の結果を前提にしないと正しく動かないなら、それらは別 middleware ではなく、1 つの責務としてまとめるか、Store 本体の state/action 設計で表現したほうがよい。
+- registration order を強い契約として前提にすると、`middleware(...)` の並び順が実質的な仕様になり、変更耐性が落ちやすい。
+- 並行実行であれば、「各 `Middleware` は独立した観測者・拡張として振る舞う」という期待に揃えやすい。
+- Store は各 hook で全 middleware の完了を待つ。そのため、`CONCURRENT` でも fire-and-forget にはならず、完了待ちは維持される。
+- 一部の統合事情、移行事情、あるいは処理順を明示したいケースでは直列実行も自然な選択になり得るため、`IN_REGISTRATION_ORDER` も選択肢として残す。
+
+## 未解決事項
+
+- なし


### PR DESCRIPTION
## Summary
- add an internal decision note documenting why MiddlewareExecutionPolicy defaults to CONCURRENT
- clarify that middleware should stay loosely coupled and that ordered execution remains an explicit opt-in
- record that store hooks still wait for all middleware to complete under concurrent execution

## Why
- preserve the reasoning behind the default policy in a durable internal document
- make future changes and reviews easier by documenting the intended middleware design constraints

## Impact
- documentation only
- no runtime behavior changes

## Verification
- not run (documentation-only change)