### PR TITLE
Add internal policy discussion memos

### DIFF
--- a/doc/internal/2026-04-23-event-sharedflow-policy.md
+++ b/doc/internal/2026-04-23-event-sharedflow-policy.md
@@ -1,0 +1,42 @@
+# Event 用 MutableSharedFlow の設定方針
+
+- 状態: 決定済み
+- 更新日: 2026-04-23
+- 関連: [StoreImpl.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt)、[Store.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt)、[ViewStore.kt](../../tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt)、[Message.kt](../../tart-message/src/commonMain/kotlin/io/yumemi/tart/message/Message.kt)
+
+## 背景
+
+`Store.event` は UI 向けの one-shot event を流す用途で使っている。現在は `MutableSharedFlow()` をそのまま使っており、実質的には `replay = 0`、`extraBufferCapacity = 0`、`onBufferOverflow = BufferOverflow.SUSPEND` になっている。
+
+ここで検討したのは次の 3 点。
+
+- `replay` を増やすべきか、または明示的に設定しておくべきか
+- `buffer` や `overflow` を内部で明示的に設定しておくべきか
+- それらの挙動を利用者が policy として選べるようにするべきか
+
+## 結論
+
+現時点では、`Store.event` と `MessageHub` の `MutableSharedFlow` について、`replay`、`buffer`、`overflow` は追加で設定しない。
+
+あわせて、`SharedFlow` の生の設定値を利用者に公開して選ばせる API も追加しない。
+
+採用する前提は次のとおり。
+
+- `replay = 0` を維持する
+- `extraBufferCapacity = 0` を維持する
+- `onBufferOverflow` は明示しない
+
+## 補足
+
+- `replay = 0` は、後から購読を始めた側に過去イベントを再配送しないために適している。UI event の再配信は、画面の再生成や再購読のたびに navigation、toast、snackbar などの one-shot event が再発火する原因になりやすい。
+- `replay` を 1 以上にする案も検討対象だったが、`Store.event` の意味を「その場で購読していた側に届く通知」から「直近イベントの再通知があり得る通知」に変えてしまうため採用しない。
+- `extraBufferCapacity` は「すでに購読中だが遅い collector がいるときに、producer を少し先行させる」ための設定であり、「購読前のイベントを保持する」ための設定ではない。
+- `onBufferOverflow` は buffer を持たせたときにだけ実質的な意味を持つ。`DROP_OLDEST` や `DROP_LATEST` はイベントを黙って捨てる方針なので、汎用の event delivery policy としては強すぎる。
+- 現状の `emit` が suspend する挙動は、遅い collector がいるときに backpressure をそのまま受けるが、そのぶんイベントを静かに落とさない。`Store.event` の既定動作としてはこちらを優先する。
+- 設定値をそのまま公開すると、利用者に `SharedFlow` 内部仕様の理解を要求しやすく、API 表面積のわりに得られる一貫した意味づけが弱い。特に `replay` は UI event の再配送と密接に結びつくため、生の数値を公開するより高水準の意味で設計すべき項目である。
+- 将来、実運用で「遅い event handler により Store 側の処理が詰まる」問題が確認された場合は、まず内部実装として小さい `extraBufferCapacity` を追加する案を再検討する。その場合でも、最初の候補は `SUSPEND` を維持したままの小容量 buffer とする。
+- 可読性のために `MutableSharedFlow(replay = 0, extraBufferCapacity = 0)` のように明示する変更はあり得るが、これは挙動変更ではなく意図の明文化として扱う。
+
+## 未解決事項
+
+- 実利用で event collector の遅延が問題になる具体例が出た場合にのみ、内部 buffer の導入を再評価する。

--- a/doc/internal/2026-04-23-store-start-policy.md
+++ b/doc/internal/2026-04-23-store-start-policy.md
@@ -1,0 +1,63 @@
+# Store の開始タイミング policy 案
+
+- 状態: メモ
+- 更新日: 2026-04-23
+- 関連: [StoreImpl.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt)、[StoreBuilder.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt)、[Store.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt)、[StoreInternalApi.kt](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreInternalApi.kt)、[StoreBaseTest.kt](../../tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt)、[StoreObserverTest.kt](../../tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt)、[ViewStore.kt](../../tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt)
+
+## 背景
+
+現状の Store は、最初の `dispatch()` または `state.collect` / `collectState()` をきっかけに起動する。
+
+起動時には `initializeIfNeeded()` が呼ばれ、middleware の `onStart` を含む start 時の処理が実行される。
+
+このため、利用者が `state` を collect しただけでも start に紐づく副作用が走る。
+Compose の `rememberViewStore()` は内部で `store.state.collectAsState()` を呼ぶため、画面が Store を購読した時点で Store が起動しうる。
+
+一方で、次の挙動は start 前でも成立している。
+
+- `currentState` は読める
+- `stateSaver.restore()` により復元された state も start 前に見える
+- `attachObserver()` は start 前にだけ許可される
+- `collectEvent()` は現状 start のトリガーではない
+
+この組み合わせを見ると、検討対象は個別の handler 単位ではなく、「Store をいつ start とみなすか」の方が自然である。
+
+## 結論
+
+初期化ポリシーを追加するなら、個別の DSL handler ではなく Store の開始タイミング全体を制御する policy として導入する。
+
+名前は仮に `StoreStartPolicy` とし、まずは次の 3 つを候補にする。
+
+- `ON_FIRST_DISPATCH_OR_STATE_COLLECTION`
+  - 現状互換の default
+  - 最初の `dispatch()` または `state` の collect で start する
+- `ON_FIRST_DISPATCH`
+  - `dispatch()` でのみ start する
+  - `state` の collect は start のトリガーにしない
+- `MANUAL`
+  - 自動 start しない
+  - 利用者が明示的に `start()` を呼んだときだけ start する
+
+設定 API は既存の policy と同じ流儀で `StoreBuilder` / `StoreOverridesBuilder` に追加するのが自然である。
+
+```kt
+fun startPolicy(policy: StoreStartPolicy)
+```
+
+`MANUAL` を成立させるために、明示的に start する API が別途必要になる。
+
+## 補足
+
+- `PendingActionPolicy` や `MiddlewareExecutionPolicy` と同じく、enum ベースの高水準 policy にした方が API の意味を保ちやすい。`Boolean` や生の trigger 群を公開すると、組み合わせは増えるが利用者から見た意味が弱くなる。
+- policy が制御する対象は startup processing 全体とする。ここを分けると start の概念が二重化し、middleware・observer・テストの整合が崩れやすい。
+- `ON_FIRST_STATE_COLLECTION` のような collect 専用 policy は v1 では不要。`dispatch()` したのに start しない挙動は直感に反しやすい。
+- 未採用候補として `EAGER` も考えられる。これは「`dispatch()` や `state` の collect を待たず、Store 作成直後に start する」という意味になる。v1 では見送るのがよい。`attachObserver()` が start 前のみ許可という現行前提と衝突しやすい。
+- `ON_FIRST_DISPATCH` では、`state` を collect しても start しない。その場合でも `StateFlow` としては current snapshot を読めるので、UI が「現在値の監視」と「副作用の開始」を分離しやすくなる。
+- `MANUAL` で start 前に `dispatch()` された場合は、暗黙 start や silently ignore ではなく、例外で失敗させる方がバグを早く見つけやすい。
+
+## 未解決事項
+
+- 明示 start API を `Store` interface に載せるか、core 内の extension として追加するかは未決定。interface 追加は fake 実装への影響があり、extension は Tart 実装依存であることをどう見せるかを考える必要がある。
+- `collectEvent()` を start trigger に含めるかは未決定。現状は含まれていないが、利用者視点では `event` 監視も start と結び付くと期待される可能性がある。
+- `MANUAL` で start 前に `state` を collect した場合の README 上の説明を明確にする必要がある。current snapshot は流れるが、start に紐づく副作用はまだ走らない、という説明になる見込み。
+- `rememberViewStore()` 利用時に `ON_FIRST_DISPATCH` や `MANUAL` を選んだときのサンプルを README / Compose 側テストに追加する必要がある。


### PR DESCRIPTION
## Summary
- add an internal memo for the Event MutableSharedFlow configuration policy
- add an internal memo for Store start timing policy options
- capture rationale and open questions for future runtime-policy work

## Why
These notes document recent design discussions in doc/internal and make the reasoning easier to trace from the codebase.

## Verification
- Not run (documentation only)