### PR TITLE
Document action async boundary decisions

### DIFF
--- a/doc/internal/adr/2026-04-26-action-async-boundary.md
+++ b/doc/internal/adr/2026-04-26-action-async-boundary.md
@@ -1,0 +1,34 @@
+# `action` の async 境界は明示のまま維持する
+
+- 更新日: 2026-04-26
+- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [非 `launch` 処理には cancellation API を入れない](./2026-04-26-non-launch-cancellation.md)
+
+## 背景
+
+`action {}` は現状、Store の直列 pipeline 上で実行される handler であり、必要に応じて `action { launch { ... } }` により state scope にぶら下がる非同期処理を開始できる。
+
+このとき、次の 2 案を検討した。
+
+- `action {}` を default で `action { launch { ... } }` 相当にし、利用者の `dispatch()` を常に並行に処理しやすくする案
+- `action {}` と `action { launch { ... } }` の二段構えは維持しつつ、`action {}` 直下では外部 I/O や長い suspend を書かせない方向へ寄せる案
+
+前者は Store を塞ぎにくくするが、後者は async 境界を明示したまま保ちやすい。
+一方で、後者を型で強制するには既存 API の breaking change が必要になる可能性がある。
+
+## 決定
+
+`action` の async 境界は、当面、明示の `launch {}` によって表す形を維持する。
+
+- `action {}` を default で async / parallel handler にはしない
+- `action {}` と `action { launch { ... } }` の二段構えは維持する
+- 通常の `action {}` は、短く終わる直列・原子的な store work として扱う
+- 外部 I/O、長い待ち時間、cancellation が必要な仕事、state に所有させたい継続処理は `launch {}` に出す前提で整理する
+- ただし現時点では、`action {}` を non-suspend に変える breaking change は入れず、まずは設計指針とドキュメントでこの運用を明確にする
+
+## 補足
+
+- `action {}` を default async にすると、state transition の順序、`dispatchAndWait()` の完了単位、middleware の前後関係、`PendingActionPolicy` の意味が読みづらくなる。
+- Tart では「action は処理開始のきっかけであり、継続中の仕事の所有者は state」という整理を取っている。そのため、継続する仕事の入口を `launch {}` として明示する方が設計全体と整合する。
+- 一方で、`action {}` 直下で長い suspend や外部 I/O を許すと、Store 全体を塞ぎやすい。この問題は実際に起こりうるが、解決策として default async 化を採るのは副作用が大きい。
+- `action {}` を non-suspend にする案は思想としては筋がよいが、現状の `event()` を含む DSL 形状と衝突しやすく、導入コストに対して runtime 上の利益は限定的である。
+- `launch {}` を安易に増やすと、複数 async job 間の整合性、古い結果の採用防止、event 発火順の読みやすさなどを利用者が管理する負担が増える。したがって、`launch {}` は必要な箇所でだけ明示的に使う escape hatch として残す。

--- a/doc/internal/notes/2026-04-23-store-start-policy.md
+++ b/doc/internal/notes/2026-04-23-store-start-policy.md
@@ -1,6 +1,6 @@
 # Store の開始タイミング policy 案
 
-- 更新日: 2026-04-23
+- 更新日: 2026-04-26
 
 ## 背景
 
@@ -51,6 +51,10 @@ fun startPolicy(policy: StoreStartPolicy)
 - `ON_FIRST_STATE_COLLECTION` のような collect 専用 policy は v1 では不要。`dispatch()` したのに start しない挙動は直感に反しやすい。
 - 未採用候補として `EAGER` も考えられる。これは「`dispatch()` や `state` の collect を待たず、Store 作成直後に start する」という意味になる。v1 では見送るのがよい。`attachObserver()` が start 前のみ許可という現行前提と衝突しやすい。
 - `ON_FIRST_DISPATCH` では、`state` を collect しても start しない。その場合でも `StateFlow` としては current snapshot を読めるので、UI が「現在値の監視」と「副作用の開始」を分離しやすくなる。
+- start 直後に `enter { event(...) }` のような one-shot event を出したい場合、現状の default では `state` の collect が先に start trigger になり、あとから `event` を購読した側が初回 event を見逃しうる。
+- この問題は Compose の `rememberViewStore()` でも起こりうる。`rememberViewStore()` は内部で `store.state.collectAsState()` を行う一方、event の collect は `ViewStore.handle()` 側の `LaunchedEffect` で始まるため、同じ画面内で両方を書いていても event collector が start 前に間に合う保証はない。
+- この問題に対しては start policy が有効な回避策になりうる。`ON_FIRST_DISPATCH` なら `state` / `event` の購読を張ったあとに明示的な最初の `dispatch()` で start でき、`MANUAL` なら購読を張ったあとに `start()` を呼ぶ順序をさらに明示しやすい。
+- ただし start policy が解決するのは「購読前に start しない」ことまでであり、`Store.event` 自体の replay semantics は変えない。start 後に購読した側へ過去 event を再配送するわけではない。
 - `MANUAL` で start 前に `dispatch()` された場合は、暗黙 start や silently ignore ではなく、例外で失敗させる方がバグを早く見つけやすい。
 
 ## 未解決事項


### PR DESCRIPTION
## Summary
- add an ADR describing why `action {}` keeps an explicit async boundary through `launch {}`
- expand the store start policy notes with the event-missed-on-start scenario and how `ON_FIRST_DISPATCH` and `MANUAL` help
- refresh the start policy note date to reflect the new discussion

## Why
- capture the current design direction around action concurrency and store startup timing in the internal docs
- make the event timing tradeoff and mitigation options explicit for future implementation discussions

## Verification
- not run (documentation changes only)