### PR TITLE
Rename public dispatcher parameters

### DIFF
--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -180,7 +180,7 @@ class ViewStoreJvmTest {
         val store = Store<UiState, UiAction, UiEvent>(initialState = UiState.Loading) {
             coroutineContext(coroutineContext)
             state<UiState.Loading> {
-                enter(coroutineDispatcher = testDispatcher) {
+                enter(dispatcher = testDispatcher) {
                     enterGate.await()
                     nextState(UiState.Ready(0))
                 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
@@ -19,8 +19,8 @@ interface MiddlewareScope<A : Action> {
     /**
      * Launches a coroutine within the store's scope.
      *
-     * @param coroutineDispatcher The dispatcher to use for the coroutine (defaults to Dispatchers.Unconfined)
+     * @param dispatcher The dispatcher to use for the coroutine (defaults to Dispatchers.Unconfined)
      * @param block The coroutine body to execute
      */
-    fun launch(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend CoroutineScope.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend CoroutineScope.() -> Unit)
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -126,12 +126,12 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     class StateHandlerConfig<S : State, A : Action, E : Event, S2 : S> {
 
         class ThreadedHandler<P, SC : StoreScope>(
-            private val coroutineDispatcher: CoroutineDispatcher,
+            private val dispatcher: CoroutineDispatcher,
             val predicate: P,
             private val handler: suspend SC.() -> Unit,
         ) {
             suspend operator fun invoke(scope: SC) {
-                withContext(coroutineDispatcher) {
+                withContext(dispatcher) {
                     handler(scope)
                 }
             }
@@ -144,26 +144,26 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
 
         /**
          * Registers a handler to be invoked when entering this state with the specified CoroutineDispatcher.
-         * If no coroutineDispatcher is provided, Dispatchers.Unconfined is used as default.
+         * If no dispatcher is provided, Dispatchers.Unconfined is used as default.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for executing the enter handler (defaults to Dispatchers.Unconfined)
+         * @param dispatcher The CoroutineDispatcher to use for executing the enter handler (defaults to Dispatchers.Unconfined)
          * @param block The handler function that will be executed when entering this state
          */
-        fun enter(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend EnterScope<S, A, E, S2>.() -> Unit) {
-            stateEnterHandlers.add(ThreadedHandler(coroutineDispatcher, null, block))
+        fun enter(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend EnterScope<S, A, E, S2>.() -> Unit) {
+            stateEnterHandlers.add(ThreadedHandler(dispatcher, null, block))
         }
 
         /**
          * Registers a handler for a specific action type in the current state configuration
          * with an optional CoroutineDispatcher.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for executing the action handler, defaults to Dispatchers.Unconfined
+         * @param dispatcher The CoroutineDispatcher to use for executing the action handler, defaults to Dispatchers.Unconfined
          * @param block The handler function that processes the action and updates the state
          */
-        inline fun <reified A2 : A> action(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, noinline block: suspend ActionScope<S, A2, E, S2>.() -> Unit) {
+        inline fun <reified A2 : A> action(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, noinline block: suspend ActionScope<S, A2, E, S2>.() -> Unit) {
             stateActionHandlers.add(
                 ThreadedHandler(
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     predicate = { it is A2 },
                     handler = {
                         @Suppress("UNCHECKED_CAST")
@@ -175,26 +175,26 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
 
         /**
          * Registers a handler to be invoked when exiting this state with the specified CoroutineDispatcher.
-         * If no coroutineDispatcher is provided, Dispatchers.Unconfined is used as default.
+         * If no dispatcher is provided, Dispatchers.Unconfined is used as default.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for executing the exit handler (defaults to Dispatchers.Unconfined)
+         * @param dispatcher The CoroutineDispatcher to use for executing the exit handler (defaults to Dispatchers.Unconfined)
          * @param block The handler function that will be executed when exiting this state
          */
-        fun exit(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend ExitScope<S, E, S2>.() -> Unit) {
-            stateExitHandlers.add(ThreadedHandler(coroutineDispatcher, null, block))
+        fun exit(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend ExitScope<S, E, S2>.() -> Unit) {
+            stateExitHandlers.add(ThreadedHandler(dispatcher, null, block))
         }
 
         /**
          * Registers a handler for a specific error type in the current state configuration
          * with an optional CoroutineDispatcher.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for executing the error handler, defaults to Dispatchers.Unconfined
+         * @param dispatcher The CoroutineDispatcher to use for executing the error handler, defaults to Dispatchers.Unconfined
          * @param block The handler function that processes the error and updates the state
          */
-        inline fun <reified T : Throwable> error(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
+        inline fun <reified T : Throwable> error(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
             stateErrorHandlers.add(
                 ThreadedHandler(
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     predicate = { it is T },
                     handler = {
                         @Suppress("UNCHECKED_CAST")

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -176,8 +176,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                         this@StoreImpl.dispatch(action)
                     }
 
-                    override fun launch(coroutineDispatcher: CoroutineDispatcher, block: suspend CoroutineScope.() -> Unit) {
-                        coroutineScope.launch(coroutineDispatcher) {
+                    override fun launch(dispatcher: CoroutineDispatcher, block: suspend CoroutineScope.() -> Unit) {
+                        coroutineScope.launch(dispatcher) {
                             block()
                         }
                     }
@@ -313,7 +313,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 }
 
                 override fun launch(
-                    coroutineDispatcher: CoroutineDispatcher,
+                    dispatcher: CoroutineDispatcher,
                     key: Any?,
                     mode: LaunchMode,
                     block: suspend ActionScope.LaunchScope<S, A, E, S>.() -> Unit,
@@ -323,7 +323,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                         stateRuntime = stateRuntime,
                         key = key ?: action::class,
                         mode = mode,
-                        coroutineDispatcher = coroutineDispatcher,
+                        dispatcher = dispatcher,
                         buildLaunchScope = { buildActionLaunchScope(stateRuntime.scope, action) },
                         block = block,
                     )
@@ -362,10 +362,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     emit(event)
                 }
 
-                override fun launch(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope<S, E, S>.() -> Unit) {
+                override fun launch(dispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope<S, E, S>.() -> Unit) {
                     launchInStateRuntime(
                         stateRuntime = stateRuntime,
-                        coroutineDispatcher = coroutineDispatcher,
+                        dispatcher = dispatcher,
                         buildLaunchScope = { buildEnterLaunchScope(stateRuntime.scope) },
                         block = block,
                     )
@@ -379,14 +379,14 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private fun <LS> launchInStateRuntime(
         stateRuntime: StateRuntime,
-        coroutineDispatcher: CoroutineDispatcher,
+        dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
         block: suspend LS.() -> Unit,
     ): Job {
-        return stateRuntime.scope.launch(coroutineDispatcher) {
+        return stateRuntime.scope.launch(dispatcher) {
             executeLaunchInStateRuntime(
                 stateRuntime = stateRuntime,
-                coroutineDispatcher = coroutineDispatcher,
+                dispatcher = dispatcher,
                 buildLaunchScope = buildLaunchScope,
                 block = block,
             )
@@ -397,7 +397,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         stateRuntime: StateRuntime,
         key: Any,
         mode: LaunchMode,
-        coroutineDispatcher: CoroutineDispatcher,
+        dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
         block: suspend LS.() -> Unit,
     ) {
@@ -405,7 +405,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             LaunchMode.CONCURRENT -> {
                 launchInStateRuntime(
                     stateRuntime = stateRuntime,
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
                 )
@@ -416,7 +416,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 stateRuntime.actionLaunchJobs[key] = launchTrackedActionInStateRuntime(
                     stateRuntime = stateRuntime,
                     key = key,
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
                 )
@@ -427,7 +427,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 stateRuntime.actionLaunchJobs[key] = launchTrackedActionInStateRuntime(
                     stateRuntime = stateRuntime,
                     key = key,
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
                 )
@@ -438,15 +438,15 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private fun <LS> launchTrackedActionInStateRuntime(
         stateRuntime: StateRuntime,
         key: Any,
-        coroutineDispatcher: CoroutineDispatcher,
+        dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
         block: suspend LS.() -> Unit,
     ): Job {
-        return stateRuntime.scope.launch(coroutineDispatcher) {
+        return stateRuntime.scope.launch(dispatcher) {
             try {
                 executeLaunchInStateRuntime(
                     stateRuntime = stateRuntime,
-                    coroutineDispatcher = coroutineDispatcher,
+                    dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
                 )
@@ -460,7 +460,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun <LS> executeLaunchInStateRuntime(
         stateRuntime: StateRuntime,
-        coroutineDispatcher: CoroutineDispatcher,
+        dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
         block: suspend LS.() -> Unit,
     ) {
@@ -469,7 +469,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             block(launchScope)
         } catch (t: Throwable) {
             rethrowIfFatal(t)
-            coroutineScope.launch(coroutineDispatcher) {
+            coroutineScope.launch(dispatcher) {
                 mutex.withLock {
                     if (stateRuntime.scope.isActive) {
                         onErrorOccurred(currentState, t)
@@ -487,8 +487,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 emit(event)
             }
 
-            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
-                val job = coroutineScope.launch(coroutineDispatcher) {
+            override suspend fun transaction(dispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
+                val job = coroutineScope.launch(dispatcher) {
                     mutex.withLock {
                         if (stateScope.isActive) {
                             var newState: S? = null
@@ -539,8 +539,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 emit(event)
             }
 
-            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend ActionScope.LaunchScope.TransactionScope<S, A, E, S>.() -> Unit) {
-                val job = coroutineScope.launch(coroutineDispatcher) {
+            override suspend fun transaction(dispatcher: CoroutineDispatcher, block: suspend ActionScope.LaunchScope.TransactionScope<S, A, E, S>.() -> Unit) {
+                val job = coroutineScope.launch(dispatcher) {
                     mutex.withLock {
                         if (stateScope.isActive) {
                             var newState: S? = null

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -54,10 +54,10 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Launches a coroutine within the context of this state.
      * The coroutine will be automatically cancelled when the state is exited.
      *
-     * @param coroutineDispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
+     * @param dispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
      * @param block The suspending block of code to execute
      */
-    fun launch(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend LaunchScope<S, E, S2>.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend LaunchScope<S, E, S2>.() -> Unit)
 
     /**
      * Scope available within a launched coroutine.
@@ -85,10 +85,10 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
          * Executes a transactional operation within the launch scope.
          * This allows state updates to be performed in an atomic, consistent manner.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
+         * @param dispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
          * @param block The suspending block of code to execute as a transaction
          */
-        suspend fun transaction(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, E, S2>.() -> Unit)
+        suspend fun transaction(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, E, S2>.() -> Unit)
 
         /**
          * Scope available within a transaction operation.
@@ -210,12 +210,12 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Launches a coroutine within the context of the current state where this action is processed.
      * The coroutine will be automatically cancelled when this state is exited.
      *
-     * @param coroutineDispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
+     * @param dispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
      * @param key Optional launch key used for launch coordination. When omitted, the current action type is used.
      * @param mode The launch mode used when the same key is launched repeatedly.
      * @param block The suspending block of code to execute
      */
-    fun launch(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, key: Any? = null, mode: LaunchMode = LaunchMode.CONCURRENT, block: suspend LaunchScope<S, A, E, S2>.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, key: Any? = null, mode: LaunchMode = LaunchMode.CONCURRENT, block: suspend LaunchScope<S, A, E, S2>.() -> Unit)
 
     /**
      * Scope available within a launched coroutine from an action handler.
@@ -248,10 +248,10 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
          * Executes a transactional operation within the launch scope.
          * This allows state updates to be performed in an atomic, consistent manner.
          *
-         * @param coroutineDispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
+         * @param dispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
          * @param block The suspending block of code to execute as a transaction
          */
-        suspend fun transaction(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, A, E, S2>.() -> Unit)
+        suspend fun transaction(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, A, E, S2>.() -> Unit)
 
         /**
          * Scope available within a transaction operation.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchModeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchModeTest.kt
@@ -38,7 +38,7 @@ class StoreLaunchModeTest {
             state<AppState.Active> {
                 action<AppAction.CancelPreviousDefault> {
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
                         onCancelPreviousStart?.invoke(action.marker)
@@ -52,7 +52,7 @@ class StoreLaunchModeTest {
 
                 action<AppAction.KeyedLaunches> {
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         key = "primary",
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
@@ -61,7 +61,7 @@ class StoreLaunchModeTest {
                         }
                     }
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         key = "secondary",
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
@@ -73,7 +73,7 @@ class StoreLaunchModeTest {
 
                 action<AppAction.SharedDefaultKey> {
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
                         transaction(testDispatcher) {
@@ -81,7 +81,7 @@ class StoreLaunchModeTest {
                         }
                     }
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
                         transaction(testDispatcher) {
@@ -92,7 +92,7 @@ class StoreLaunchModeTest {
 
                 action<AppAction.DropNewAdd> {
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         mode = LaunchMode.DROP_NEW,
                     ) {
                         delay(100)
@@ -104,7 +104,7 @@ class StoreLaunchModeTest {
 
                 action<AppAction.LatestAdd> {
                     launch(
-                        coroutineDispatcher = testDispatcher,
+                        dispatcher = testDispatcher,
                         mode = LaunchMode.CANCEL_PREVIOUS,
                     ) {
                         delay(100)

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
@@ -12,11 +12,11 @@ import kotlinx.coroutines.Dispatchers
  * Middleware that logs Store operations.
  *
  * @param logger Logger to use
- * @param coroutineDispatcher Coroutine dispatcher to use for log processing
+ * @param dispatcher Coroutine dispatcher to use for log processing
  */
 abstract class LoggingMiddleware<S : State, A : Action, E : Event>(
     private val logger: Logger = DefaultLogger,
-    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
 ) : Middleware<S, A, E> {
     private lateinit var middlewareScope: MiddlewareScope<A>
 
@@ -25,7 +25,7 @@ abstract class LoggingMiddleware<S : State, A : Action, E : Event>(
     }
 
     protected fun log(severity: Logger.Severity, tag: String, throwable: Throwable? = null, message: () -> String) {
-        middlewareScope.launch(coroutineDispatcher) { // launch Coroutines to avoid blocking Store processing in case of heavy logging
+        middlewareScope.launch(dispatcher) { // launch Coroutines to avoid blocking Store processing in case of heavy logging
             logger.log(severity = severity, tag = tag, throwable = throwable, message = message())
         }
     }
@@ -39,18 +39,18 @@ abstract class LoggingMiddleware<S : State, A : Action, E : Event>(
  * @param tag The tag to use for logging
  * @param severity The severity level for log messages
  * @param logger The logger implementation to use
- * @param coroutineDispatcher The dispatcher for logging operations
+ * @param dispatcher The dispatcher for logging operations
  * @return A middleware that performs logging for all store operations
  */
 fun <S : State, A : Action, E : Event> simpleLogging(
     tag: String = "Tart",
     severity: Logger.Severity = Logger.Severity.Debug,
     logger: Logger = DefaultLogger,
-    coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
+    dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
 ): Middleware<S, A, E> {
     return object : LoggingMiddleware<S, A, E>(
         logger = logger,
-        coroutineDispatcher = coroutineDispatcher,
+        dispatcher = dispatcher,
     ) {
         override suspend fun beforeActionDispatch(state: S, action: A) {
             log(severity, tag) { "Action: $action" }

--- a/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
+++ b/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
@@ -20,7 +20,7 @@ class LoggingMiddlewareTest {
         val testLogger = TestLogger()
         val middleware = simpleLogging<CounterState, CounterAction, Nothing>(
             logger = testLogger,
-            coroutineDispatcher = Dispatchers.Unconfined,
+            dispatcher = Dispatchers.Unconfined,
         )
 
         val store = createTestStore(CounterState(10), middleware)


### PR DESCRIPTION
## Summary
- rename public API parameters from `coroutineDispatcher` to `dispatcher`
- update internal implementations and repository call sites to match the renamed public signatures

## Why
- simplify dispatcher-related API naming across the public DSL and logging helpers

## Impact
- callers using named arguments must update `coroutineDispatcher = ...` to `dispatcher = ...`

## Verification
- `./gradlew :tart-core:jvmTest :tart-logging:jvmTest :tart-compose:jvmTest`