### PR TITLE
Add LaunchLane-based action launch control

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,7 @@ If you want lightweight coordination and explicit cancellation for coroutines la
 
 ```kt
 val store = Store(MyState.Active()) {
-    val searchLane = object {}
-    val submitLane = object {}
+    val searchLane = LaunchLane()
 
     state<MyState.Active> {
         action<MyAction.QueryChanged> {
@@ -518,7 +517,7 @@ val store = Store(MyState.Active()) {
         }
 
         action<MyAction.Submit> {
-            launch(control = LaunchControl.DropNew(submitLane)) {
+            launch(control = LaunchControl.DropNew()) {
                 submit()
             }
         }
@@ -526,10 +525,11 @@ val store = Store(MyState.Active()) {
 }
 ```
 
-`LaunchControl.Replace(key)` cancels the previous tracked launch in the same lane before starting the next one.
-`LaunchControl.DropNew(key)` ignores new launches while tracked work in the same lane is still active.
+`LaunchControl.Replace(lane)` cancels the previous tracked launch in the same lane before starting the next one.
+`LaunchControl.DropNew(lane)` ignores new launches while tracked work in the same lane is still active.
+When the lane is omitted, `LaunchControl.Replace()` and `LaunchControl.DropNew()` use the same internal default lane for that `action {}` block.
 `LaunchControl.Concurrent` keeps the default behavior and runs launches independently.
-`cancelLaunch(key)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.Replace(...)` and `LaunchControl.DropNew(...)`. It does not cancel `LaunchControl.Concurrent` launches or `enter { launch { ... } }`.
+`cancelLaunch(lane)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.Replace(...)` and `LaunchControl.DropNew(...)`. Use an explicit `LaunchLane()` when you need to share a lane across multiple launches or cancel it later. It does not cancel `LaunchControl.Concurrent` launches or `enter { launch { ... } }`.
 
 ### Specifying coroutineContext
 

--- a/doc/internal/adr/2026-04-26-non-launch-cancellation.md
+++ b/doc/internal/adr/2026-04-26-non-launch-cancellation.md
@@ -5,7 +5,7 @@
 
 ## 背景
 
-`#190` では、`action { launch { ... } }` で開始した仕事を key 単位で明示的に止める `cancelLaunch(key)` を検討している。
+`#190` では、`action { launch { ... } }` で開始した仕事を lane 単位で明示的に止める `cancelLaunch(lane)` を検討している。
 
 一方で、`launch` を使わない通常の `action {}`、`enter {}`、`exit {}`、`error {}`、および `transaction {}` には、いま実行中の処理を途中で止める API はない。
 

--- a/doc/internal/adr/2026-04-27-clear-pending-actions-scope.md
+++ b/doc/internal/adr/2026-04-27-clear-pending-actions-scope.md
@@ -31,7 +31,7 @@
 
 - `clearPendingActions()` が意味を持つのは、「いま何が current store work で、その後ろに何が pending か」が直列 pipeline 上で定まっているときである。
 - `launch {}` 本体は state に所有される非同期処理であり、store の直列 pipeline そのものではない。ここで queue を直接掃除できるようにすると、遅延や I/O の後の任意の時点で pending action を破棄できてしまい、挙動を追いにくくなる。
-- `launch {}` 本体で必要なのは queue 制御よりも、state-owned job の寿命制御である。そちらは `cancelLaunch(key)` のような action-launch cancellation で扱う方が役割分離として自然である。
+- `launch {}` 本体で必要なのは queue 制御よりも、state-owned job の寿命制御である。そちらは `cancelLaunch(lane)` のような action-launch cancellation で扱う方が役割分離として自然である。
 - launched coroutine から `transaction {}` に入った時点では、処理は再び store の直列 pipeline に戻る。そのため、その瞬間に「この結果を採用するなら、古い pending action は不要」と判断して `clearPendingActions()` を呼ぶのは意味が通る。
 - `enter {}`、`exit {}`、`error {}` も技術的には store work であり、そこで pending action を捨てる意味はある。したがって公開面から完全に外す必要まではない。
 - ただし、可読性の観点では `action {}` と `transaction {}` の方が「何を確定させた結果として queue を切るのか」を読み取りやすい。README や KDoc では、この利用の重心を明示した方がよい。

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
@@ -1,12 +1,21 @@
 package io.yumemi.tart.core
 
 /**
+ * Stable token used to coordinate tracked coroutines launched from `action {}`.
+ *
+ * Reuse the same instance when multiple launches should share a lane or when the
+ * lane should be cancellable via `cancelLaunch(...)`.
+ */
+class LaunchLane
+
+/**
  * Controls how coroutines launched from an `action {}` handler coordinate with
  * previous work from the same action lane.
  *
- * [Concurrent] launches are not tracked by key.
- * [Replace] and [DropNew] create tracked lanes with explicit keys that can also
- * be targeted by `cancelLaunch(key)`.
+ * [Concurrent] launches are not tracked by lane.
+ * [Replace] and [DropNew] create tracked lanes. When [LaunchLane] is omitted,
+ * the launch uses an internal default lane that is fixed for the current
+ * `action {}` block.
  */
 sealed interface LaunchControl {
 
@@ -19,10 +28,10 @@ sealed interface LaunchControl {
      * Cancel the previous tracked asynchronous job in the same lane before
      * starting a new one.
      */
-    data class Replace(val key: Any) : LaunchControl
+    data class Replace(val lane: LaunchLane? = null) : LaunchControl
 
     /**
      * Ignore new launches while tracked work in the same lane is still active.
      */
-    data class DropNew(val key: Any) : LaunchControl
+    data class DropNew(val lane: LaunchLane? = null) : LaunchControl
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -312,9 +312,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     emit(event)
                 }
 
-                override fun cancelLaunch(key: Any) {
+                override fun cancelLaunch(lane: LaunchLane) {
                     val stateRuntime = stateRuntimes[state::class] ?: throw InternalError(IllegalStateException("[Tart] State scope is not found"))
-                    cancelTrackedActionLaunch(stateRuntime, key)
+                    cancelTrackedActionLaunch(stateRuntime, lane)
                 }
 
                 override fun launch(
@@ -325,6 +325,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     val stateRuntime = stateRuntimes[state::class] ?: throw InternalError(IllegalStateException("[Tart] State scope is not found"))
                     launchActionInStateRuntime(
                         stateRuntime = stateRuntime,
+                        action = action,
                         control = control,
                         dispatcher = dispatcher,
                         buildLaunchScope = { buildActionLaunchScope(stateRuntime.scope, action) },
@@ -398,6 +399,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private fun <LS> launchActionInStateRuntime(
         stateRuntime: StateRuntime,
+        action: A,
         control: LaunchControl,
         dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
@@ -414,11 +416,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             }
 
             is LaunchControl.Replace -> {
-                val key = control.key
-                cancelTrackedActionLaunch(stateRuntime, key)
-                stateRuntime.actionLaunchJobs[key] = launchTrackedActionInStateRuntime(
+                val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
+                cancelTrackedActionLaunch(stateRuntime, trackedKey)
+                stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
                     stateRuntime = stateRuntime,
-                    key = key,
+                    trackedKey = trackedKey,
                     dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
@@ -426,11 +428,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             }
 
             is LaunchControl.DropNew -> {
-                val key = control.key
-                if (stateRuntime.actionLaunchJobs[key]?.isActive == true) return
-                stateRuntime.actionLaunchJobs[key] = launchTrackedActionInStateRuntime(
+                val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
+                if (stateRuntime.actionLaunchJobs[trackedKey]?.isActive == true) return
+                stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
                     stateRuntime = stateRuntime,
-                    key = key,
+                    trackedKey = trackedKey,
                     dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
@@ -441,7 +443,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private fun <LS> launchTrackedActionInStateRuntime(
         stateRuntime: StateRuntime,
-        key: Any,
+        trackedKey: Any,
         dispatcher: CoroutineDispatcher,
         buildLaunchScope: () -> LS,
         block: suspend LS.() -> Unit,
@@ -455,15 +457,23 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     block = block,
                 )
             } finally {
-                if (stateRuntime.actionLaunchJobs[key] === coroutineContext[Job]) {
-                    stateRuntime.actionLaunchJobs.remove(key)
+                if (stateRuntime.actionLaunchJobs[trackedKey] === coroutineContext[Job]) {
+                    stateRuntime.actionLaunchJobs.remove(trackedKey)
                 }
             }
         }
     }
 
-    private fun cancelTrackedActionLaunch(stateRuntime: StateRuntime, key: Any) {
-        stateRuntime.actionLaunchJobs.remove(key)?.cancel()
+    private fun resolveTrackedActionLaunchKey(action: A, control: LaunchControl): Any {
+        return when (control) {
+            LaunchControl.Concurrent -> error("Concurrent launches do not have a tracked lane")
+            is LaunchControl.Replace -> control.lane ?: action::class
+            is LaunchControl.DropNew -> control.lane ?: action::class
+        }
+    }
+
+    private fun cancelTrackedActionLaunch(stateRuntime: StateRuntime, trackedKey: Any) {
+        stateRuntime.actionLaunchJobs.remove(trackedKey)?.cancel()
     }
 
     private suspend fun <LS> executeLaunchInStateRuntime(

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -207,15 +207,15 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     suspend fun event(event: E)
 
     /**
-     * Cancels active coroutines launched from action handlers with the given key
+     * Cancels active coroutines launched from action handlers with the given lane
      * in the current state's runtime when those launches are tracked by their launch control
      * such as [LaunchControl.Replace] or [LaunchControl.DropNew].
      *
      * If no matching launch exists, this is a no-op.
      *
-     * @param key The launch key identifying the cancellation group
+     * @param lane The explicit launch lane identifying the cancellation group
      */
-    fun cancelLaunch(key: Any)
+    fun cancelLaunch(lane: LaunchLane)
 
     /**
      * Launches a coroutine within the context of the current state where this action is processed.
@@ -223,7 +223,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      *
      * @param dispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
      * @param control The launch control used for coordination. Tracked controls
-     * require an explicit launch key.
+     * may use an explicit [LaunchLane] or the action-local default lane.
      * @param block The suspending block of code to execute
      */
     fun launch(dispatcher: CoroutineDispatcher = Dispatchers.Unconfined, control: LaunchControl = LaunchControl.Concurrent, block: suspend LaunchScope<S, A, E, S2>.() -> Unit)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreCancelLaunchTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreCancelLaunchTest.kt
@@ -11,6 +11,9 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StoreCancelLaunchTest {
+    private val sharedLane = LaunchLane()
+    private val otherLane = LaunchLane()
+    private val missingLane = LaunchLane()
 
     sealed interface AppState : State {
         data object Active : AppState
@@ -49,7 +52,7 @@ class StoreCancelLaunchTest {
                 action<AppAction.StartDropNewShared> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew("shared"),
+                        control = LaunchControl.DropNew(sharedLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -63,7 +66,7 @@ class StoreCancelLaunchTest {
                 action<AppAction.StartDropNewOther> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew("other"),
+                        control = LaunchControl.DropNew(otherLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -77,7 +80,7 @@ class StoreCancelLaunchTest {
                 action<AppAction.StartReplaceShared> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace("shared"),
+                        control = LaunchControl.Replace(sharedLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -107,18 +110,18 @@ class StoreCancelLaunchTest {
                 }
 
                 action<AppAction.CancelShared> {
-                    cancelLaunch("shared")
+                    cancelLaunch(sharedLane)
                 }
 
                 action<AppAction.CancelMissing> {
-                    cancelLaunch("missing")
+                    cancelLaunch(missingLane)
                 }
             }
         }
     }
 
     @Test
-    fun cancelLaunch_cancelsDropNewLaunchWithMatchingKey() = runTest {
+    fun cancelLaunch_cancelsDropNewLaunchWithMatchingLane() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val cancelled = mutableListOf<Int>()
         val store = createStore(
@@ -136,7 +139,7 @@ class StoreCancelLaunchTest {
     }
 
     @Test
-    fun cancelLaunch_cancelsReplaceLaunchWithMatchingKey() = runTest {
+    fun cancelLaunch_cancelsReplaceLaunchWithMatchingLane() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val started = mutableListOf<Int>()
         val cancelled = mutableListOf<Int>()
@@ -177,7 +180,7 @@ class StoreCancelLaunchTest {
     }
 
     @Test
-    fun cancelLaunch_isNoOpWhenKeyDoesNotExist() = runTest {
+    fun cancelLaunch_isNoOpWhenLaneDoesNotExist() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val cancelled = mutableListOf<Int>()
         val store = createStore(

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchControlTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchControlTest.kt
@@ -12,10 +12,6 @@ import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StoreLaunchControlTest {
-    private companion object {
-        const val SharedLane = "shared"
-    }
-
     sealed interface AppState : State {
         data class Active(val value: Int = 0) : AppState
         data object Completed : AppState
@@ -24,7 +20,8 @@ class StoreLaunchControlTest {
     sealed interface AppAction : Action {
         data class ReplaceDefault(val marker: Int) : AppAction
         data object KeyedLaunches : AppAction
-        data object SharedDefaultKey : AppAction
+        data object SharedDefaultLane : AppAction
+        data object SharedDefaultLaneAcrossControls : AppAction
         data class DropNewAdd(val delta: Int) : AppAction
         data class LatestAdd(val delta: Int) : AppAction
         data object MoveToCompleted : AppAction
@@ -35,6 +32,8 @@ class StoreLaunchControlTest {
         onReplaceStart: ((Int) -> Unit)? = null,
         onReplaceCancel: ((Int) -> Unit)? = null,
     ): Store<AppState, AppAction, Nothing> {
+        val primaryLane = LaunchLane()
+        val secondaryLane = LaunchLane()
         return Store(AppState.Active()) {
             coroutineContext(testDispatcher)
 
@@ -42,7 +41,7 @@ class StoreLaunchControlTest {
                 action<AppAction.ReplaceDefault> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(AppAction.ReplaceDefault::class),
+                        control = LaunchControl.Replace(),
                     ) {
                         onReplaceStart?.invoke(action.marker)
                         try {
@@ -56,7 +55,7 @@ class StoreLaunchControlTest {
                 action<AppAction.KeyedLaunches> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace("primary"),
+                        control = LaunchControl.Replace(primaryLane),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 1))
@@ -64,7 +63,7 @@ class StoreLaunchControlTest {
                     }
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace("secondary"),
+                        control = LaunchControl.Replace(secondaryLane),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 10))
@@ -72,10 +71,10 @@ class StoreLaunchControlTest {
                     }
                 }
 
-                action<AppAction.SharedDefaultKey> {
+                action<AppAction.SharedDefaultLane> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(SharedLane),
+                        control = LaunchControl.Replace(),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 1))
@@ -83,7 +82,27 @@ class StoreLaunchControlTest {
                     }
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(SharedLane),
+                        control = LaunchControl.Replace(),
+                    ) {
+                        transaction(testDispatcher) {
+                            nextState(state.copy(value = state.value + 10))
+                        }
+                    }
+                }
+
+                action<AppAction.SharedDefaultLaneAcrossControls> {
+                    launch(
+                        dispatcher = testDispatcher,
+                        control = LaunchControl.Replace(),
+                    ) {
+                        delay(100)
+                        transaction(testDispatcher) {
+                            nextState(state.copy(value = state.value + 1))
+                        }
+                    }
+                    launch(
+                        dispatcher = testDispatcher,
+                        control = LaunchControl.DropNew(),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 10))
@@ -94,7 +113,7 @@ class StoreLaunchControlTest {
                 action<AppAction.DropNewAdd> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew(AppAction.DropNewAdd::class),
+                        control = LaunchControl.DropNew(),
                     ) {
                         delay(100)
                         transaction(testDispatcher) {
@@ -106,7 +125,7 @@ class StoreLaunchControlTest {
                 action<AppAction.LatestAdd> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(AppAction.LatestAdd::class),
+                        control = LaunchControl.Replace(),
                     ) {
                         delay(100)
                         transaction(testDispatcher) {
@@ -123,7 +142,7 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_replaceCancelsMatchingKeyAcrossDispatches() = runTest {
+    fun launchControl_replaceCancelsMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val started = mutableListOf<Int>()
         val cancelled = mutableListOf<Int>()
@@ -166,7 +185,7 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_distinctKeysKeepLaunchesIndependent() = runTest {
+    fun launchControl_distinctLanesKeepLaunchesIndependent() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 
@@ -177,18 +196,34 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_sameKeyCoordinatesLaunchesWithinHandler() = runTest {
+    fun launchControl_sameDefaultLaneCoordinatesLaunchesWithinHandler() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 
-        store.dispatch(AppAction.SharedDefaultKey)
+        store.dispatch(AppAction.SharedDefaultLane)
         runCurrent()
 
         assertEquals(AppState.Active(value = 10), store.currentState)
     }
 
     @Test
-    fun launchControl_dropNewUsesMatchingKeyAcrossDispatches() = runTest {
+    fun launchControl_defaultLaneIsSharedAcrossControlsWithinHandler() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val store = createStore(testDispatcher)
+
+        store.dispatch(AppAction.SharedDefaultLaneAcrossControls)
+        runCurrent()
+
+        assertEquals(AppState.Active(value = 0), store.currentState)
+
+        advanceTimeBy(100)
+        runCurrent()
+
+        assertEquals(AppState.Active(value = 1), store.currentState)
+    }
+
+    @Test
+    fun launchControl_dropNewUsesMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 
@@ -213,7 +248,7 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_replaceUsesMatchingKeyAcrossDispatches() = runTest {
+    fun launchControl_replaceUsesMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 


### PR DESCRIPTION
## Summary
- replace tracked action launch keys in the public API with `LaunchLane` and update `cancelLaunch(...)` accordingly
- allow `LaunchControl.Replace()` and `LaunchControl.DropNew()` to share an action-local default lane when no explicit lane is provided
- update tests, README, and internal ADR notes to reflect the lane-based API and default-lane behavior

## Why
- make shared and cancellable launch coordination explicit while keeping simple single-launch `DropNew` and `Replace` usage concise

## Verification
- `./gradlew :tart-core:jvmTest`