### PR TITLE
Use PascalCase for policy enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,13 +603,13 @@ You can also create a `StateSaver` instance with the `StateSaver()` factory func
 ### Clear Pending Actions
 
 By default, Tart clears already queued actions when the store exits the current state and enters a different state variant.
-To keep queued actions across state exits, set `pendingActionPolicy(PendingActionPolicy.KEEP)`.
+To keep queued actions across state exits, set `pendingActionPolicy(PendingActionPolicy.Keep)`.
 
 ```kt
 val store: Store<CounterState, CounterAction, CounterEvent> = Store {
     // ...
 
-    pendingActionPolicy(PendingActionPolicy.KEEP)
+    pendingActionPolicy(PendingActionPolicy.Keep)
 }
 ```
 
@@ -912,13 +912,13 @@ You can also create a `Middleware` instance with the `Middleware()` factory func
 
 Middleware methods are suspending functions. The *Store* waits for middleware processing to complete before proceeding.
 When multiple middleware instances are registered, Tart invokes them concurrently by default.
-If middleware must run one by one in registration order, set `middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)`.
+If middleware must run one by one in registration order, set `middlewareExecutionPolicy(MiddlewareExecutionPolicy.InRegistrationOrder)`.
 
 ```kt
 val store: Store<CounterState, CounterAction, CounterEvent> = Store {
     // ...
 
-    middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)
+    middlewareExecutionPolicy(MiddlewareExecutionPolicy.InRegistrationOrder)
 }
 ```
 

--- a/doc/internal/adr/2026-04-22-pending-action-policy.md
+++ b/doc/internal/adr/2026-04-22-pending-action-policy.md
@@ -1,10 +1,10 @@
 # PendingActionPolicy 拡張案の却下
 
-- 更新日: 2026-04-22
+- 更新日: 2026-04-29
 
 ## 背景
 
-現在の `PendingActionPolicy.CLEAR_ON_STATE_EXIT` は、別の state variant への遷移が確定したときだけ、すでに待機している action を捨てる。
+現在の `PendingActionPolicy.ClearOnStateExit` は、別の state variant への遷移が確定したときだけ、すでに待機している action を捨てる。
 
 検討対象にしたのは、次の 2 案。
 
@@ -24,7 +24,7 @@
 
 ## 補足
 
-- 現状の `CLEAR_ON_STATE_EXIT` は「state exit ベース」の挙動であり、「state change ベース」ではない。
+- 現状の `ClearOnStateExit` は「state exit ベース」の挙動であり、「state change ベース」ではない。
 - 「state が変更されたら捨てる」は、`state != nextState` を基準にすると効きすぎる。通常の `copy(...)` を含む多くの更新で待機 action が消えるため、一般 policy としては強すぎる。
 - 「state が変更されたら捨てる」は、利用者から見ても挙動が読みづらい。見た目には通常の state 更新でも待機 action が消えるため、どの更新が action 破棄を引き起こすのかを追いにくい。
 - その種の要件は利用頻度も高くなさそうで、汎用機能として持つより、必要な箇所で `clearPendingActions()` を呼ぶか、state の分け方や世代管理で表現するほうが意図が読みやすい。

--- a/doc/internal/adr/2026-04-23-middleware-execution-policy.md
+++ b/doc/internal/adr/2026-04-23-middleware-execution-policy.md
@@ -1,6 +1,6 @@
 # Middleware 実行ポリシーは並行を標準にする
 
-- 更新日: 2026-04-23
+- 更新日: 2026-04-29
 
 ## 背景
 
@@ -12,10 +12,10 @@ Tart では複数の `Middleware` を登録できる。
 
 ## 決定
 
-`MiddlewareExecutionPolicy` のデフォルトは `CONCURRENT` とする。
+`MiddlewareExecutionPolicy` のデフォルトは `Concurrent` とする。
 
 複数の `Middleware` を使う場合でも、それぞれは原則として互いに疎結合であるべきで、他の `Middleware` の完了や副作用を前提に設計しない、という考え方を基本にする。
-ただし `IN_REGISTRATION_ORDER` も正式な option として残す。
+ただし `InRegistrationOrder` も正式な option として残す。
 
 ## 補足
 
@@ -23,5 +23,5 @@ Tart では複数の `Middleware` を登録できる。
 - もし `Middleware A` が `Middleware B` の結果を前提にしないと正しく動かないなら、それらは別 middleware ではなく、1 つの責務としてまとめるか、Store 本体の state/action 設計で表現したほうがよい。
 - registration order を強い契約として前提にすると、`middleware(...)` の並び順が実質的な仕様になり、変更耐性が落ちやすい。
 - 並行実行であれば、「各 `Middleware` は独立した観測者・拡張として振る舞う」という期待に揃えやすい。
-- Store は各 hook で全 middleware の完了を待つ。そのため、`CONCURRENT` でも fire-and-forget にはならず、完了待ちは維持される。
-- 一部の統合事情、移行事情、あるいは処理順を明示したいケースでは直列実行も自然な選択になり得るため、`IN_REGISTRATION_ORDER` も選択肢として残す。
+- Store は各 hook で全 middleware の完了を待つ。そのため、`Concurrent` でも fire-and-forget にはならず、完了待ちは維持される。
+- 一部の統合事情、移行事情、あるいは処理順を明示したいケースでは直列実行も自然な選択になり得るため、`InRegistrationOrder` も選択肢として残す。

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareExecutionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareExecutionPolicy.kt
@@ -7,10 +7,10 @@ enum class MiddlewareExecutionPolicy {
     /**
      * Invokes middleware methods concurrently and waits until all of them complete.
      */
-    CONCURRENT,
+    Concurrent,
 
     /**
      * Invokes middleware methods one by one in registration order.
      */
-    IN_REGISTRATION_ORDER,
+    InRegistrationOrder,
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
@@ -8,10 +8,10 @@ enum class PendingActionPolicy {
      * Clears queued actions after a transition to a different state variant is committed.
      * The currently running store work keeps running.
      */
-    CLEAR_ON_STATE_EXIT,
+    ClearOnStateExit,
 
     /**
      * Keeps queued actions unless they are cleared explicitly from DSL scopes.
      */
-    KEEP,
+    Keep,
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -12,8 +12,8 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeCoroutineContext: CoroutineContext = Dispatchers.Default
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
-    private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.CLEAR_ON_STATE_EXIT
-    private var storeMiddlewareExecutionPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.CONCURRENT
+    private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit
+    private var storeMiddlewareExecutionPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.Concurrent
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -675,7 +675,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     }
 
     private fun clearPendingActionsOnStateExitIfNeeded() {
-        if (pendingActionPolicy == PendingActionPolicy.CLEAR_ON_STATE_EXIT) {
+        if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit) {
             clearPendingDispatchJobs()
         }
     }
@@ -691,13 +691,13 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private suspend fun processMiddleware(block: suspend Middleware<S, A, E>.() -> Unit) {
         try {
             when (middlewareExecutionPolicy) {
-                MiddlewareExecutionPolicy.CONCURRENT -> coroutineScope {
+                MiddlewareExecutionPolicy.Concurrent -> coroutineScope {
                     middlewares.forEach { middleware ->
                         launch { middleware.block() }
                     }
                 }
 
-                MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER -> middlewares.forEach { middleware ->
+                MiddlewareExecutionPolicy.InRegistrationOrder -> middlewares.forEach { middleware ->
                     middleware.block()
                 }
             }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExecutionPolicyTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExecutionPolicyTest.kt
@@ -27,7 +27,7 @@ class StoreMiddlewareExecutionPolicyTest {
         firstMiddlewareStarted: CompletableDeferred<Unit>,
         secondMiddlewareStarted: CompletableDeferred<Unit>,
         firstMiddlewareCanFinish: CompletableDeferred<Unit>,
-        setupPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.CONCURRENT,
+        setupPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.Concurrent,
         overrides: Overrides<AppState, AppAction, Nothing> = {},
     ): Store<AppState, AppAction, Nothing> {
         return Store(
@@ -111,7 +111,7 @@ class StoreMiddlewareExecutionPolicyTest {
             firstMiddlewareStarted = firstMiddlewareStarted,
             secondMiddlewareStarted = secondMiddlewareStarted,
             firstMiddlewareCanFinish = firstMiddlewareCanFinish,
-            setupPolicy = MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER,
+            setupPolicy = MiddlewareExecutionPolicy.InRegistrationOrder,
         )
 
         store.dispatch(AppAction.Increment)
@@ -144,9 +144,9 @@ class StoreMiddlewareExecutionPolicyTest {
             firstMiddlewareStarted = firstMiddlewareStarted,
             secondMiddlewareStarted = secondMiddlewareStarted,
             firstMiddlewareCanFinish = firstMiddlewareCanFinish,
-            setupPolicy = MiddlewareExecutionPolicy.CONCURRENT,
+            setupPolicy = MiddlewareExecutionPolicy.Concurrent,
             overrides = {
-                middlewareExecutionPolicy(MiddlewareExecutionPolicy.IN_REGISTRATION_ORDER)
+                middlewareExecutionPolicy(MiddlewareExecutionPolicy.InRegistrationOrder)
             },
         )
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
@@ -185,11 +185,11 @@ class StoreOverridesTest {
         val store = Store<PendingPolicyState, PendingPolicyAction, Nothing>(
             initialState = PendingPolicyState.Initial,
             overrides = {
-                pendingActionPolicy(PendingActionPolicy.KEEP)
+                pendingActionPolicy(PendingActionPolicy.Keep)
             },
         ) {
             coroutineContext(testDispatcher)
-            pendingActionPolicy(PendingActionPolicy.CLEAR_ON_STATE_EXIT)
+            pendingActionPolicy(PendingActionPolicy.ClearOnStateExit)
 
             state<PendingPolicyState.Initial> {
                 action<PendingPolicyAction.EnterActiveAfterDelay>(testDispatcher) {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
@@ -33,7 +33,7 @@ class StorePendingActionCancellationTest {
     ): Store<AppState, AppAction, Nothing> {
         return Store(AppState.Active()) {
             coroutineContext(testDispatcher)
-            pendingActionPolicy(PendingActionPolicy.KEEP)
+            pendingActionPolicy(PendingActionPolicy.Keep)
 
             state<AppState.Active> {
                 action<AppAction.HoldAndCancel>(testDispatcher) {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionPolicyTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionPolicyTest.kt
@@ -27,7 +27,7 @@ class StorePendingActionPolicyTest {
 
     private fun createStore(
         testDispatcher: TestDispatcher,
-        pendingActionPolicy: PendingActionPolicy = PendingActionPolicy.CLEAR_ON_STATE_EXIT,
+        pendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit,
         onTransitionStarted: CompletableDeferred<Unit>? = null,
         onTransitionCompleted: CompletableDeferred<Unit>? = null,
     ): Store<AppState, AppAction, Nothing> {
@@ -87,7 +87,7 @@ class StorePendingActionPolicyTest {
         val transitionStarted = CompletableDeferred<Unit>()
         val store = createStore(
             testDispatcher = testDispatcher,
-            pendingActionPolicy = PendingActionPolicy.KEEP,
+            pendingActionPolicy = PendingActionPolicy.Keep,
             onTransitionStarted = transitionStarted,
         )
 


### PR DESCRIPTION
## Summary
- rename `PendingActionPolicy` and `MiddlewareExecutionPolicy` enum entries to PascalCase
- update store implementation, tests, README, and ADR references to the new enum entry names
- refresh the ADR update dates after syncing the documented API names

## Why
- align these DSL-facing enum entries with Kotlin-style PascalCase naming and existing enum usage in the repository

## Verification
- `./gradlew :tart-core:jvmTest`