### PR TITLE
Make nextStateBy use the current state as receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ val store: Store<CounterState, CounterAction, Nothing> = Store {
 
 Define how *Action*s change *State* using the `state{}` and `action{}` blocks.
 Specify the resulting *State* with `nextState()`.
-If you want to compute and return the next state inside a block, use `nextStateBy { ... }`.
+If you want to compute and return the next state inside a block whose receiver is the current state, use `nextStateBy { ... }`.
 If neither `nextState()` nor `nextStateBy()` is specified, the current state remains unchanged.
 
 ```kt
@@ -138,7 +138,7 @@ For conditional or complex updates, `nextStateBy {}` can make the computation ea
 nextStateBy {
     // ...
     val newCount = ...
-    state.copy(count = newCount)
+    copy(count = newCount)
 }
 ```
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -301,8 +301,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = state
                 }
 
-                override fun nextStateBy(block: () -> S) {
-                    newState = block()
+                override fun nextStateBy(block: S.() -> S) {
+                    newState = state.block()
                 }
 
                 override fun clearPendingActions() {
@@ -355,8 +355,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = state
                 }
 
-                override fun nextStateBy(block: () -> S) {
-                    newState = block()
+                override fun nextStateBy(block: S.() -> S) {
+                    newState = state.block()
                 }
 
                 override fun clearPendingActions() {
@@ -518,8 +518,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = state
                                 }
 
-                                override fun nextStateBy(block: () -> S) {
-                                    newState = block()
+                                override fun nextStateBy(block: S.() -> S) {
+                                    newState = currentState.block()
                                 }
 
                                 override fun clearPendingActions() {
@@ -571,8 +571,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = state
                                 }
 
-                                override fun nextStateBy(block: () -> S) {
-                                    newState = block()
+                                override fun nextStateBy(block: S.() -> S) {
+                                    newState = currentState.block()
                                 }
 
                                 override fun clearPendingActions() {
@@ -649,8 +649,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = state
                 }
 
-                override fun nextStateBy(block: () -> S) {
-                    newState = block()
+                override fun nextStateBy(block: S.() -> S) {
+                    newState = state.block()
                 }
 
                 override fun clearPendingActions() {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -31,9 +31,9 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Updates the current state with a new state value computed from the given block.
      * Used within enter handlers to modify the state with computed values.
      *
-     * @param block A function that computes and returns the new state
+     * @param block A function whose receiver is the current state and that returns the new state
      */
-    fun nextStateBy(block: () -> S)
+    fun nextStateBy(block: S2.() -> S)
 
     /**
      * Clears actions that are already queued behind the currently executing store work.
@@ -114,9 +114,9 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
              * Updates the current state with a new state value computed from the given block.
              * Used within transaction blocks to modify the state with computed values.
              *
-             * @param block A function that computes and returns the new state
+             * @param block A function whose receiver is the current state and that returns the new state
              */
-            fun nextStateBy(block: () -> S)
+            fun nextStateBy(block: S2.() -> S)
 
             /**
              * Clears actions that are already queued behind the currently executing store work.
@@ -189,9 +189,9 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Updates the current state with a new state value computed from the given block.
      * Used within action handlers to modify the state with computed values.
      *
-     * @param block A function that computes and returns the new state
+     * @param block A function whose receiver is the current state and that returns the new state
      */
-    fun nextStateBy(block: () -> S)
+    fun nextStateBy(block: S2.() -> S)
 
     /**
      * Clears actions that are already queued behind the currently executing store work.
@@ -295,9 +295,9 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
              * Updates the current state with a new state value computed from the given block.
              * Used within transaction blocks to modify the state with computed values.
              *
-             * @param block A function that computes and returns the new state
+             * @param block A function whose receiver is the current state and that returns the new state
              */
-            fun nextStateBy(block: () -> S)
+            fun nextStateBy(block: S2.() -> S)
 
             /**
              * Clears actions that are already queued behind the currently executing store work.
@@ -344,9 +344,9 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
      * Updates the current state with a new state value computed from the given block.
      * Used within error handlers to modify the state with computed values.
      *
-     * @param block A function that computes and returns the new state
+     * @param block A function whose receiver is the current state and that returns the new state
      */
-    fun nextStateBy(block: () -> S)
+    fun nextStateBy(block: S2.() -> S)
 
     /**
      * Clears actions that are already queued behind the currently executing store work.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
@@ -68,7 +68,7 @@ class FlowCollectUseCaseTest {
                     launch {
                         dataFlow.collect { value ->
                             transaction {
-                                nextStateBy { state.copy(value = value) }
+                                nextStateBy { copy(value = value) }
                             }
                         }
                     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -166,11 +166,11 @@ class TodoUseCaseTest {
 
                     nextStateBy {
                         // Create updated todo list
-                        val updatedTodoList = state.todos.map {
+                        val updatedTodoList = todos.map {
                             if (it.id == action.todoId) savedTodo else it
                         }
 
-                        state.copy(todos = updatedTodoList)
+                        copy(todos = updatedTodoList)
                     }
                 }
 
@@ -199,7 +199,7 @@ class TodoUseCaseTest {
 
                     nextStateBy {
                         // Create updated todo list with the edited task
-                        val updatedTodoList = state.allTodos.map {
+                        val updatedTodoList = allTodos.map {
                             if (it.id == savedTodo.id) savedTodo else it
                         }
 


### PR DESCRIPTION
## Summary
- update `nextStateBy` to evaluate its block with the current state as receiver across enter, action, error, and transaction scopes
- refresh tests and README examples to use receiver-style state construction such as `copy(...)` and direct state member access

## Why
- align `nextStateBy` with its intended role as the place where the next state is built
- remove repeated `state.` qualifiers when constructing the next state inside the block

## Impact
- this changes the public `nextStateBy` function signature, so callers need to recompile and update any assumptions about the block receiver

## Verification
- `./gradlew :tart-core:jvmTest`