### PR TITLE
Clarify Tart DSL semantics in ADR and KDoc

### DIFF
--- a/doc/internal/adr/2026-04-30-next-state-dual-api.md
+++ b/doc/internal/adr/2026-04-30-next-state-dual-api.md
@@ -1,0 +1,70 @@
+# State 遷移指定 API は `nextState()` と `nextStateBy {}` の 2 本を維持する
+
+- 更新日: 2026-04-30
+- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md)
+
+## 背景
+
+Store DSL では、handler の結果として採用する次の state を指定する API をどう表現するかを整理したい。
+
+検討対象は主に次の点である。
+
+- `nextState(state)` と `nextStateBy { ... }` の 2 本を維持するか、1 本に寄せるか
+- `nextStateBy {}` の block に state receiver を渡すか
+- `nextStateBy {}` の block に `it` などの引数を渡すか
+- `nextState` 系ではなく `setState` / `updateState` のような名前へ寄せるか
+- `newState = ...` や `state.update { ... }` のような書き方へ寄せるか
+
+この判断では、呼び出し側の読みやすさだけでなく、実際の意味論との整合も重要になる。
+
+現在の Store 実装は、handler の途中で state を逐次更新しているわけではない。
+各 handler は内部で「最終的に採用する next state」を 1 つ保持し、handler 終了時にその値を採用する。
+そのため、`nextState(...)` や `nextStateBy { ... }` を同じ handler 内で複数回呼んだ場合も、途中の state が順に反映されるのではなく、最後に指定された値が採用される。
+
+この意味論を踏まえると、即時反映や累積更新を強く連想させる名前や block 形は避けた方がよい。
+
+## 決定
+
+State 遷移指定 API は、引き続き次の 2 本を維持する。
+
+- `nextState(state)`
+- `nextStateBy { ... }`
+
+それぞれの役割は次のとおりとする。
+
+- `nextState(state)` は、すでに次の state 値が手元にある場合や、1 行で素直に書ける遷移に使う。
+- `nextStateBy { ... }` は、中間変数や分岐を書きながら次の state を組み立てる場合に使う。
+
+`nextStateBy {}` の block には state receiver を渡さない。
+また、`it` のような引数も基本形にはしない。
+block 内で現在の state を参照したい場合は、scope が持つ `state` をそのまま使う。
+
+```kt
+nextState(AppState.Loading)
+
+nextStateBy {
+    val updated = state.items.map { item ->
+        if (item.id == action.id) item.copy(done = true) else item
+    }
+    state.copy(items = updated)
+}
+```
+
+`nextState { ... }` のような block 版への統一は行わない。
+また、`setState(...)` や `updateState { ... }` への改名も行わない。
+`newState = ...` や `state.update { ... }` のような別表現も採用しない。
+
+複数回の state 指定が起きた場合の挙動は、現状どおり後勝ちとする。
+つまり、同一 handler 内で複数回 `nextState(...)` / `nextStateBy { ... }` を呼んだ場合は、最後に指定された値だけが採用される。
+
+## 補足
+
+- `nextStateBy {}` の `by` は、「ここは別の DSL scope ではなく、その場で次の state を Kotlin のコードで組み立てる場所」という意図を表す。`nextState {}` だと `state {}` や `action {}` と同じ見た目になり、設定用 DSL block のように見えやすい。
+- state receiver を渡す案は、`copy(...)` を短く書ける利点はあるが、`action`、`error`、`event()`、`clearPendingActions()` など外側 scope のメンバとの境界が曖昧になりやすい。Tart のように scope が多い DSL では、暗黙の `this` を増やさない方が読みやすい。
+- `it` や明示引数を使う案もあるが、`state.copy(...)` の方が「何を元に次の state を作っているか」が直接読み取りやすい。block の役割は計算であり、引数経由の短縮を優先しない。
+- `setState(...)` は即時反映に、`updateState { ... }` は逐次的または累積的な更新に読まれやすい。しかし実際の意味論は「handler の結果として採用する next state を 1 つ選ぶ」であり、これらの名前は実態より強い期待を生みやすい。
+- `newState = ...` は「普通の Kotlin の代入」に見える利点はあるが、公開 DSL としては mutable な結果 slot をそのまま見せることになる。`newState` を途中で読めるのか、複数回代入した場合はどうなるのか、未代入は何を意味するのかといった契約が API ににじみやすいため採用しない。
+- `state.update { ... }` は、現在の `state` をその場で mutate する、あるいは `MutableStateFlow.update` のように現在値へ順次更新を積む API に見えやすい。しかし Tart の `state` は scope が持つ現在 state の snapshot 値であり、意味論は「state 自体を更新する」のではなく「handler の結果として next state を選ぶ」である。このため `state.update { ... }` は実際の挙動よりも可変オブジェクト操作に近く読まれやすく、採用しない。
+- 後勝ちは積極的に活用させたい機能ではないが、分岐や早期 return を含む handler で最終結果を自然に決められる fallback semantics としては妥当である。必要なら README / KDoc / test でこの挙動を明記する。
+- `先勝ち` も採用しない。通常の Kotlin コードでは、上から順に読んで後ろの代入や指定が最終結果になると受け取られやすい。`nextState(A)` の後に `nextState(B)` が書かれていても `A` が採用される設計は、後ろの記述が見えているのに効かないため、`後勝ち` よりも驚きが大きい。もし複数指定をより厳しく扱いたいなら、無言の `先勝ち` にするより、重複指定をエラーとして検知する方向の方が自然である。
+- `state<S2>` / `action<A2>` の handler 解決は registration order による先勝ちである一方、選ばれた handler の中での `nextState(...)` / `nextStateBy { ... }` は後勝ちになる。この組み合わせは初見では少し引っかかりうるが、両者は別レイヤーの挙動である。前者は「どの rule を採用するか」という routing であり、後者は「採用された rule の結果を何にするか」という result selection である。同じ勝ち方に無理に揃えるより、routing は先勝ち、結果指定は後勝ちとして、それぞれの層で自然な振る舞いを採る方が分かりやすい。

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 interface MiddlewareScope<A : Action> {
     /**
      * Dispatches an action to the store.
+     * This enqueues the action and returns immediately.
+     * It does not wait for action handling to complete.
      *
      * @param action The action to dispatch
      */
@@ -17,6 +19,8 @@ interface MiddlewareScope<A : Action> {
 
     /**
      * Launches a coroutine within the store's scope.
+     * The launched coroutine is tied to the Store lifecycle and is cancelled when the Store is disposed.
+     * It is not cancelled automatically when the current state changes.
      *
      * @param dispatcher Optional CoroutineDispatcher override for the coroutine.
      * When null, the coroutine inherits the Store's current execution context.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -148,6 +148,8 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         /**
          * Registers a handler to be invoked when entering this state with the specified CoroutineDispatcher.
          * If no dispatcher is provided, the handler runs in the Store's current execution context.
+         * If multiple `enter {}` handlers can match the current state, the first registered handler is used.
+         * Supplying a dispatcher changes where the handler runs, but the Store still waits for it to finish.
          *
          * @param dispatcher Optional CoroutineDispatcher override for executing the enter handler
          * @param block The handler function that will be executed when entering this state
@@ -159,6 +161,9 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         /**
          * Registers a handler for a specific action type in the current state configuration
          * with an optional CoroutineDispatcher.
+         * If multiple `action {}` handlers can match the current state and action,
+         * the first registered handler is used.
+         * Supplying a dispatcher changes where the handler runs, but the Store still waits for it to finish.
          *
          * @param dispatcher Optional CoroutineDispatcher override for executing the action handler
          * @param block The handler function that processes the action and updates the state
@@ -179,6 +184,8 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         /**
          * Registers a handler to be invoked when exiting this state with the specified CoroutineDispatcher.
          * If no dispatcher is provided, the handler runs in the Store's current execution context.
+         * If multiple `exit {}` handlers can match the current state, the first registered handler is used.
+         * Supplying a dispatcher changes where the handler runs, but the Store still waits for it to finish.
          *
          * @param dispatcher Optional CoroutineDispatcher override for executing the exit handler
          * @param block The handler function that will be executed when exiting this state
@@ -190,6 +197,9 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         /**
          * Registers a handler for a specific error type in the current state configuration
          * with an optional CoroutineDispatcher.
+         * If multiple `error {}` handlers can match the current state and error,
+         * the first registered handler is used.
+         * Supplying a dispatcher changes where the handler runs, but the Store still waits for it to finish.
          *
          * @param dispatcher Optional CoroutineDispatcher override for executing the error handler
          * @param block The handler function that processes the error and updates the state
@@ -212,6 +222,8 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     /**
      * Configures handlers for actions when the store is in a specific state type.
      * This creates a DSL scope for defining type-specific action handlers.
+     * Handler selection is first-match in registration order.
+     * If both broad and specific handlers can match, place broader handlers later.
      *
      * @param block The configuration block where you can define action handlers using the action() function
      */

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -15,21 +15,26 @@ sealed interface StoreScope
 @TartStoreDsl
 interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     /**
-     * The current state that's being entered
+     * The current state snapshot when this handler is executing.
+     * This value does not change immediately when [nextState] or [nextStateBy] is called.
      */
     val state: S2
 
     /**
-     * Updates the current state with a new state value.
-     * Used within enter handlers to modify the state.
+     * Registers the next state to apply after the current enter handler finishes.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
      *
      * @param state The new state value to update to
      */
     fun nextState(state: S)
 
     /**
-     * Updates the current state with a new state value computed from the given block.
-     * Used within enter handlers to modify the state with computed values.
+     * Registers the next state to apply after the current enter handler finishes
+     * by computing it in the given block.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
+     * If neither [nextState] nor [nextStateBy] is called, the current [state] is kept.
      *
      * @param block A function that computes and returns the new state
      */
@@ -42,8 +47,8 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun clearPendingActions()
 
     /**
-     * Emits an event from the enter handler.
-     * Use this to communicate with the outside world about important occurrences.
+     * Emits an event immediately from the current enter handler.
+     * Emission is not deferred until after a next state registered in this handler is applied.
      *
      * @param event The event to emit
      */
@@ -74,8 +79,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         val isActive: Boolean
 
         /**
-         * Emits an event from the launched coroutine.
-         * Use this to communicate with the outside world about important occurrences.
+         * Emits an event immediately from the launched coroutine.
          *
          * @param event The event to emit
          */
@@ -98,21 +102,26 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         @TartStoreDsl
         interface TransactionScope<S : State, E : Event, S2 : S> : StoreScope {
             /**
-             * The current state when the transaction is being executed
+             * The current state snapshot when this transaction is executing.
+             * This value does not change immediately when [nextState] or [nextStateBy] is called.
              */
             val state: S2
 
             /**
-             * Updates the current state with a new state value.
-             * Used within transaction blocks to modify the state.
+             * Registers the next state to apply after the current transaction finishes.
+             * This does not update [state] immediately.
+             * If called multiple times in the same transaction, the last specified state is used.
              *
              * @param state The new state value to update to
              */
             fun nextState(state: S)
 
             /**
-             * Updates the current state with a new state value computed from the given block.
-             * Used within transaction blocks to modify the state with computed values.
+             * Registers the next state to apply after the current transaction finishes
+             * by computing it in the given block.
+             * This does not update [state] immediately.
+             * If called multiple times in the same transaction, the last specified state is used.
+             * If neither [nextState] nor [nextStateBy] is called, the current [state] is kept.
              *
              * @param block A function that computes and returns the new state
              */
@@ -125,8 +134,8 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun clearPendingActions()
 
             /**
-             * Emits an event from the transaction.
-             * Use this to communicate with the outside world about important occurrences.
+             * Emits an event immediately from the current transaction.
+             * Emission is not deferred until after a next state registered in this transaction is applied.
              *
              * @param event The event to emit
              */
@@ -142,7 +151,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
 @TartStoreDsl
 interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
     /**
-     * The current state that's being exited
+     * The current state snapshot when this handler is executing.
      */
     val state: S2
 
@@ -153,8 +162,7 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
     fun clearPendingActions()
 
     /**
-     * Emits an event from the exit handler.
-     * Use this to communicate with the outside world about important occurrences.
+     * Emits an event immediately from the current exit handler.
      *
      * @param event The event to emit
      */
@@ -168,7 +176,8 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
 @TartStoreDsl
 interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     /**
-     * The current state when the action is being processed
+     * The current state snapshot when this handler is executing.
+     * This value does not change immediately when [nextState] or [nextStateBy] is called.
      */
     val state: S2
 
@@ -178,16 +187,20 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     val action: A
 
     /**
-     * Updates the current state with a new state value.
-     * Used within action handlers to modify the state.
+     * Registers the next state to apply after the current action handler finishes.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
      *
      * @param state The new state value to update to
      */
     fun nextState(state: S)
 
     /**
-     * Updates the current state with a new state value computed from the given block.
-     * Used within action handlers to modify the state with computed values.
+     * Registers the next state to apply after the current action handler finishes
+     * by computing it in the given block.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
+     * If neither [nextState] nor [nextStateBy] is called, the current [state] is kept.
      *
      * @param block A function that computes and returns the new state
      */
@@ -200,8 +213,8 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun clearPendingActions()
 
     /**
-     * Emits an event from the action handler.
-     * Use this to communicate with the outside world about important occurrences.
+     * Emits an event immediately from the current action handler.
+     * Emission is not deferred until after a next state registered in this handler is applied.
      *
      * @param event The event to emit
      */
@@ -250,8 +263,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         val action: A
 
         /**
-         * Emits an event from the launched coroutine.
-         * Use this to communicate with the outside world about important occurrences.
+         * Emits an event immediately from the launched coroutine.
          *
          * @param event The event to emit
          */
@@ -274,7 +286,8 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         @TartStoreDsl
         interface TransactionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             /**
-             * The current state when the transaction is being executed
+             * The current state snapshot when this transaction is executing.
+             * This value does not change immediately when [nextState] or [nextStateBy] is called.
              */
             val state: S2
 
@@ -284,16 +297,20 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             val action: A
 
             /**
-             * Updates the current state with a new state value.
-             * Used within transaction blocks to modify the state.
+             * Registers the next state to apply after the current transaction finishes.
+             * This does not update [state] immediately.
+             * If called multiple times in the same transaction, the last specified state is used.
              *
              * @param state The new state value to update to
              */
             fun nextState(state: S)
 
             /**
-             * Updates the current state with a new state value computed from the given block.
-             * Used within transaction blocks to modify the state with computed values.
+             * Registers the next state to apply after the current transaction finishes
+             * by computing it in the given block.
+             * This does not update [state] immediately.
+             * If called multiple times in the same transaction, the last specified state is used.
+             * If neither [nextState] nor [nextStateBy] is called, the current [state] is kept.
              *
              * @param block A function that computes and returns the new state
              */
@@ -306,8 +323,8 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun clearPendingActions()
 
             /**
-             * Emits an event from the transaction.
-             * Use this to communicate with the outside world about important occurrences.
+             * Emits an event immediately from the current transaction.
+             * Emission is not deferred until after a next state registered in this transaction is applied.
              *
              * @param event The event to emit
              */
@@ -323,7 +340,8 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
 @TartStoreDsl
 interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     /**
-     * The current state when the error occurred
+     * The current state snapshot when this handler is executing.
+     * This value does not change immediately when [nextState] or [nextStateBy] is called.
      */
     val state: S2
 
@@ -333,16 +351,20 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     val error: T
 
     /**
-     * Updates the current state with a new state value.
-     * Used within error handlers to modify the state.
+     * Registers the next state to apply after the current error handler finishes.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
      *
      * @param state The new state value to update to
      */
     fun nextState(state: S)
 
     /**
-     * Updates the current state with a new state value computed from the given block.
-     * Used within error handlers to modify the state with computed values.
+     * Registers the next state to apply after the current error handler finishes
+     * by computing it in the given block.
+     * This does not update [state] immediately.
+     * If called multiple times in the same handler, the last specified state is used.
+     * If neither [nextState] nor [nextStateBy] is called, the current [state] is kept.
      *
      * @param block A function that computes and returns the new state
      */
@@ -355,8 +377,8 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     fun clearPendingActions()
 
     /**
-     * Emits an event from the error handler.
-     * Use this to communicate with the outside world about important occurrences.
+     * Emits an event immediately from the current error handler.
+     * Emission is not deferred until after a next state registered in this handler is applied.
      *
      * @param event The event to emit
      */


### PR DESCRIPTION
## Summary
- add an internal ADR for keeping `nextState()` and `nextStateBy {}` as separate APIs and document the related design tradeoffs
- clarify KDoc for `StoreScope`, `StoreBuilder`, and `MiddlewareScope` around deferred state application, immediate event emission, first-match handler selection, dispatcher behavior, and middleware scope lifetime

## Why
- make DSL behavior easier to understand directly from IDE docs
- reduce ambiguity around handler selection, when state updates take effect, and how middleware-scoped async work behaves

## Impact
- documentation only; no runtime behavior changes

## Verification
- not run (documentation-only changes)