### PR TITLE
Refine internal ADR related references

### DIFF
--- a/doc/internal/adr/2026-04-26-action-async-boundary.md
+++ b/doc/internal/adr/2026-04-26-action-async-boundary.md
@@ -1,7 +1,7 @@
 # `action` の async 境界は明示のまま維持する
 
-- 更新日: 2026-04-26
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [非 `launch` 処理には cancellation API を入れない](./2026-04-26-non-launch-cancellation.md)
+- 更新日: 2026-04-30
+- 関連: [非 `launch` 処理には cancellation API を入れない](./2026-04-26-non-launch-cancellation.md)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-26-middleware-dispatch-only.md
+++ b/doc/internal/adr/2026-04-26-middleware-dispatch-only.md
@@ -1,7 +1,7 @@
 # Middleware には直接 state 更新 API を入れない
 
-- 更新日: 2026-04-29
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [Middleware 実行ポリシーは並行を標準にする](./2026-04-23-middleware-execution-policy.md)
+- 更新日: 2026-04-30
+- 関連: [Middleware 実行ポリシーは並行を標準にする](./2026-04-23-middleware-execution-policy.md)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-26-non-launch-cancellation.md
+++ b/doc/internal/adr/2026-04-26-non-launch-cancellation.md
@@ -1,7 +1,7 @@
 # 非 `launch` 処理には cancellation API を入れない
 
-- 更新日: 2026-04-26
-- 関連: [#190](https://github.com/yumemi-inc/Tart/issues/190), [PendingActionPolicy 拡張案の却下](./2026-04-22-pending-action-policy.md), [Tart の設計原則](../design/2026-04-23-design-principles.md)
+- 更新日: 2026-04-30
+- 関連: [#190](https://github.com/yumemi-inc/Tart/issues/190)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-27-message-middleware-lightweight.md
+++ b/doc/internal/adr/2026-04-27-message-middleware-lightweight.md
@@ -1,7 +1,7 @@
 # MessageMiddleware は簡易な built-in に留める
 
-- 更新日: 2026-04-27
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [Middleware 実行ポリシーは並行を標準にする](./2026-04-23-middleware-execution-policy.md), [Event 用 MutableSharedFlow の設定方針](./2026-04-23-event-sharedflow-policy.md)
+- 更新日: 2026-04-30
+- 関連: [Event 用 MutableSharedFlow の設定方針](./2026-04-23-event-sharedflow-policy.md)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-28-debounce-throttle.md
+++ b/doc/internal/adr/2026-04-28-debounce-throttle.md
@@ -1,7 +1,7 @@
 # `debounce` / `throttle` は Store の built-in として入れない
 
-- 更新日: 2026-04-28
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [`action` の async 境界は明示のまま維持する](./2026-04-26-action-async-boundary.md)
+- 更新日: 2026-04-30
+- 関連: [`action` の async 境界は明示のまま維持する](./2026-04-26-action-async-boundary.md)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-28-store-onstart-dsl.md
+++ b/doc/internal/adr/2026-04-28-store-onstart-dsl.md
@@ -1,7 +1,7 @@
 # `Store{}` DSL に state 非依存の `onStart {}` は追加しない
 
-- 更新日: 2026-04-28
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md), [Store の開始タイミング policy 案](../notes/2026-04-23-store-start-policy.md), [Middleware には直接 state 更新 API を入れない](./2026-04-26-middleware-dispatch-only.md)
+- 更新日: 2026-04-30
+- 関連: [Store の開始タイミング policy 案](../notes/2026-04-23-store-start-policy.md), [Middleware には直接 state 更新 API を入れない](./2026-04-26-middleware-dispatch-only.md)
 
 ## 背景
 

--- a/doc/internal/adr/2026-04-30-next-state-dual-api.md
+++ b/doc/internal/adr/2026-04-30-next-state-dual-api.md
@@ -1,7 +1,6 @@
 # State 遷移指定 API は `nextState()` と `nextStateBy {}` の 2 本を維持する
 
 - 更新日: 2026-04-30
-- 関連: [Tart の設計原則](../design/2026-04-23-design-principles.md)
 
 ## 背景
 


### PR DESCRIPTION
## Summary
- trim overly broad `関連` links from internal ADRs
- keep only direct internal references and issue links where relevant
- update `更新日` for the ADRs touched during the cleanup

## Why
- keep `関連` focused on documents, issues, and PRs that are directly useful when revisiting the decision
- avoid broad design-principle links unless they are explicitly central

## Verification
- Not run (documentation-only changes)