### PR TITLE
Clarify Store and messaging KDoc semantics

### DIFF
--- a/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
+++ b/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
@@ -57,6 +57,10 @@ class ViewStore<S : State, A : Action, E : Event>(
     /**
      * Handles events of a specified type.
      *
+     * This collects events after the composable enters the composition.
+     * It receives only events emitted while this handler is actively collecting.
+     * Events emitted earlier are not replayed.
+     *
      * @param block Function to process the event
      */
     @Suppress("ComposableNaming")
@@ -73,6 +77,11 @@ class ViewStore<S : State, A : Action, E : Event>(
 /**
  * Composable function that creates and returns a new ViewStore instance from a Store.
  * Monitors state changes in the Store and triggers UI redrawing.
+ *
+ * This starts collecting [Store.state] immediately, so it can start the Store before any
+ * [ViewStore.handle] collector begins observing events.
+ * As a result, startup events such as events emitted from initial `enter {}` processing
+ * may be emitted before handlers in the same composition start collecting them.
  *
  * @param key Key used to remember and retain the Store instance
  * @param autoDispose Whether to dispose the Store when the component is disposed

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
@@ -4,6 +4,12 @@ package io.yumemi.tart.core
  * Interface for intercepting Store lifecycle events.
  * By implementing Middleware, you can insert processing at various lifecycle points
  * such as action dispatch, state changes, event emission, etc.
+ *
+ * Middleware hooks are suspending functions and are awaited by the Store.
+ * Long-running work in a hook can delay Store startup, action handling, state transitions,
+ * event emission, and error processing.
+ * When work should continue in the background, start it from [onStart] or another hook using
+ * [MiddlewareScope.launch].
  */
 interface Middleware<S : State, A : Action, E : Event> {
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -6,26 +6,43 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Core interface of Tart that provides application state management.
  * It has features such as state updates, event emission, action dispatching, etc.
+ *
+ * Store startup is lazy.
+ * Startup processing begins when the first action is [dispatch]ed, when [state] is collected,
+ * or when [collectState] is called.
+ * Collecting [event] or calling [collectEvent] alone does not start the Store.
  */
 interface Store<S : State, A : Action, E : Event> : AutoCloseable {
 
     /**
      * StateFlow representing the current state. You can monitor state changes by subscribing to this.
+     *
+     * Collecting this flow starts the Store if it has not started yet.
      */
     val state: StateFlow<S>
 
     /**
      * Flow of events. You can receive events by subscribing to this.
+     *
+     * Collecting this flow does not start the Store by itself.
      */
     val event: Flow<E>
 
     /**
      * The value of the current state. Use this to get the current state without subscribing to the Flow.
+     *
+     * Reading this property does not start the Store.
+     * If a [StateSaver] restores a saved state, this may return that restored snapshot
+     * even before startup processing begins.
      */
     val currentState: S
 
     /**
-     * Dispatches an action. This triggers state changes.
+     * Dispatches an action.
+     *
+     * This enqueues the action and returns immediately.
+     * It does not wait for action handling to complete.
+     * If the Store has not started yet, this also triggers startup processing before the action runs.
      *
      * @param action The action to dispatch
      */
@@ -35,6 +52,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      * Collects state changes using a callback.
      *
      * This API is intended for platforms where [StateFlow] cannot be consumed directly.
+     * Calling this method starts the Store if it has not started yet.
      *
      * The callback runs in the Store's execution context.
      * Tart does not switch to a UI thread automatically and does not guarantee delivery
@@ -52,6 +70,9 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      * Collects events using a callback.
      *
      * This API is intended for platforms where [Flow] cannot be consumed directly.
+     * Calling this method does not start the Store by itself.
+     * If you need startup processing to run, also trigger startup through [dispatch], [state],
+     * or [collectState].
      *
      * The callback runs in the Store's execution context.
      * Tart does not switch to a UI thread automatically and does not guarantee delivery

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/Message.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/Message.kt
@@ -23,6 +23,11 @@ internal object MessageHub {
  * Extension function for sending messages to the MessageHub.
  * This allows any StoreScope to easily send messages to other components.
  *
+ * Messages are sent to a process-wide shared bus.
+ * All started Stores using `receiveMessages(...)` subscribe to the same bus.
+ * Messages are not replayed, so receivers that are not actively collecting when a message is sent
+ * will not receive that past message.
+ *
  * @param message The message to send
  */
 suspend fun StoreScope.message(message: Message) {

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
@@ -20,8 +20,11 @@ private abstract class MiddlewareImpl<S : State, A : Action, E : Event> : Middle
 
 /**
  * Creates a middleware that receives messages from the MessageHub.
- * This middleware automatically subscribes to the message flow when the store starts 
+ * This middleware automatically subscribes to the message flow when the store starts
  * and processes each message with the provided block.
+ *
+ * The underlying MessageHub is process-wide and shared across all Stores using this middleware.
+ * Messages are delivered only to active subscribers and are not replayed to Stores that start later.
  *
  * @param block The function to process received messages with MiddlewareScope as receiver
  * @return A middleware that processes messages


### PR DESCRIPTION
## Summary
- Clarify lazy Store startup, dispatch, and callback collection semantics in public KDoc.
- Document that middleware hooks are awaited and that Compose event handlers may miss startup events.
- Explain that tart-message uses a process-wide shared bus without replay.

## Why
- Make user-facing behavior explicit in API docs so consumers do not rely on incorrect startup, delivery, or ordering assumptions.

## Verification
- ./gradlew :tart-core:compileKotlinMetadata :tart-message:compileKotlinMetadata :tart-compose:compileKotlinMetadata