### PR TITLE
Add ADRs for API naming decisions

### DIFF
--- a/doc/internal/adr/2026-04-30-message-middleware-typed-receive.md
+++ b/doc/internal/adr/2026-04-30-message-middleware-typed-receive.md
@@ -1,0 +1,31 @@
+# `receiveMessages<MainMessage>` のような型絞り込み API は追加しない
+
+- 更新日: 2026-04-30
+- 関連: [MessageMiddleware は簡易な built-in に留める](./2026-04-27-message-middleware-lightweight.md)
+
+## 背景
+
+`tart-message` の `receiveMessages()` に、次のような message 型指定を追加する案を検討した。
+
+- `receiveMessages<MainMessage> { ... }`
+- `receiveMessages { message: MainMessage -> ... }`
+
+狙いは、`Message` 全体を受けて `when` や `is` で振り分ける代わりに、受信側で任意の message 型だけを自然に購読できるようにすることである。
+
+ただし `tart-message` は別モジュールであり、`StoreBuilder` に専用 DSL を追加して `Store { receiveMessages<Hoge> { ... } }` のような形に寄せることはできない。
+そのため、検討対象になるのは top-level の middleware factory である `receiveMessages()` に型指定 API を足す方向になる。
+
+## 決定
+
+`receiveMessages<MainMessage>` や `receiveMessages { message: MainMessage -> ... }` のような型絞り込み API は追加しない。
+
+現時点では、既存の `receiveMessages { message -> ... }` を維持する。
+
+## 補足
+
+- `receiveMessages()` は `Middleware<S, A, E>` を返す generic factory であり、message 型だけを追加すると `M` と `S / A / E` の複数型引数を同時に扱うことになる。
+- Kotlin では「先頭の型引数だけ明示して残りを自然に省略する」形が取りづらく、`receiveMessages<MainMessage>` の見た目を素直に成立させにくい。API 形によっては `_` を含む型引数補完に寄りやすく、呼び出しが不格好になりやすい。
+- `receiveMessages { message: MainMessage -> ... }` の形なら型引数の見た目は避けやすいが、今度は「lambda 引数型で購読対象を切り替える API」になる。現在の `receiveMessages { message -> ... }` よりも契約が見えづらく、単なる引数注釈以上の意味を持つ書き方になるため、API としてやや回りくどい。
+- `StoreBuilder` 側に member DSL を生やせれば別の見せ方もありうるが、`tart-message` が別モジュールである以上、その方向は採れない。
+- そのため今回は、「型で絞れること」よりも「top-level factory として無理のない呼び出し形」を優先し、既存 API を維持する。
+- 必要な絞り込みは、引き続き `receiveMessages { message -> when (message) { ... } }` や `if (message is MainMessage) { ... }` で表現する。

--- a/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
+++ b/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
@@ -1,0 +1,31 @@
+# `ViewStore.render` / `handle` の PascalCase 置き換えは採用しない
+
+- 更新日: 2026-04-30
+
+## 背景
+
+`ViewStore.render` / `ViewStore.handle` は `@Composable` であり、Compose の naming guideline にそのまま寄せるなら、`Unit` を返す public composable として PascalCase の名前にしたくなる。
+
+このため、次の 2 方向を検討した。
+
+- トップレベル関数として `StateContent(viewStore) {}` / `EventHandler(viewStore) {}`
+- `ViewStore` のメンバ関数として `viewStore.StateContent {}` / `viewStore.EventHandler {}`
+
+ただし、どちらも現在の `viewStore.render {}` / `viewStore.handle {}` が持つ DSL としての自然さを崩す懸念があった。
+
+## 決定
+
+`ViewStore.render` / `ViewStore.handle` を PascalCase の別 API に置き換える案は採用しない。
+
+現時点では、既存の lowerCamelCase API を維持する。
+
+- `viewStore.render<...> { ... }`
+- `viewStore.handle<...> { ... }`
+
+## 補足
+
+- トップレベル関数案は、型引数の見た目が不格好になりやすい。`StateContent<MainState>(viewStore)` のように素直に書けないことがあり、`_` を含む型引数補完や、追加の引数設計を考えないと呼び出しが整いにくい。
+- `viewStore.StateContent {}` / `viewStore.EventHandler {}` は Compose の naming guideline には寄せやすいが、明示 receiver を持つメンバ呼び出しとしては不自然に見える。`viewStore.Some()` の PascalCase は、トップレベル composable や暗黙 receiver DSL とは違い、型名やプロパティ名のような見え方になりやすい。
+- そのため今回は「Compose guideline への整合」より、「`ViewStore` DSL としての自然さ」を優先する。
+- 既存 API には `@Suppress("ComposableNaming")` が必要だが、このコストは上記の不自然さを受け入れるより小さいと判断する。
+- 将来、トップレベルでもメンバでもない、より自然な API 形が見つかった場合はあらためて検討してよい。


### PR DESCRIPTION
## Summary
- Add an ADR explaining why ViewStore.render/ViewStore.handle remain lowerCamelCase instead of moving to PascalCase Compose-style replacements.
- Add an ADR explaining why typed MessageMiddleware receive APIs such as receiveMessages<MainMessage> or receiveMessages { message: MainMessage -> ... } are not being added.

## Why
- Preserve the rationale for rejecting API shapes that make Compose usage or generic middleware factories look awkward.
- Keep these design decisions discoverable in the internal ADR set.

## Verification
- Not run (documentation-only changes).