### PR TITLE
Clarify PendingActionPolicy KDoc

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
@@ -1,17 +1,22 @@
 package io.yumemi.tart.core
 
 /**
- * Controls how queued actions are handled when the store exits the current state.
+ * Controls how queued actions are handled when the store transitions to a different state variant.
+ * Updates that stay within the same state variant are not affected.
+ * For example, with a sealed interface such as `AppState`, `AppState.Loading ->
+ * AppState.Loaded(...)` is affected, but `AppState.Loaded(items = emptyList()) ->
+ * AppState.Loaded(items = listOf(item))` is not.
  */
 enum class PendingActionPolicy {
     /**
-     * Clears queued actions after a transition to a different state variant is committed.
-     * The currently running store work keeps running.
+     * Clears already queued actions after a transition to a different state variant is committed.
+     * The currently running store work keeps running; only pending queued actions are discarded.
      */
     ClearOnStateExit,
 
     /**
-     * Keeps queued actions unless they are cleared explicitly from DSL scopes.
+     * Keeps queued actions across state-variant transitions unless they are cleared explicitly
+     * from DSL scopes by calling clearPendingActions().
      */
     Keep,
 }


### PR DESCRIPTION
## Summary
- Clarify that the policy applies only when transitioning to a different state variant.
- Add examples showing a variant transition versus an update within the same variant.
- Explain that only already queued actions are discarded.

## Why
- Make ClearOnStateExit easier to understand without exposing implementation details in the enum name.

## Verification
- Not run (documentation-only changes).