### PR TITLE
Make logger messages lazy

### DIFF
--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
@@ -1,6 +1,5 @@
 package io.yumemi.tart.logging
 
-import co.touchlab.kermit.Severity
 import co.touchlab.kermit.Logger.Companion as Kermit
 
 /**
@@ -16,16 +15,18 @@ object DefaultLogger : Logger {
      * @param severity The severity of the log
      * @param tag The tag for the log
      * @param throwable Associated exception (if any)
-     * @param message The log message
+     * @param message Provider for the log message
      */
-    override suspend fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: String) {
+    override fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: () -> String) {
         if (isDisabled) return
-        Kermit.log(
-            severity = severity.map(),
-            tag = tag,
-            throwable = throwable,
-            message = message,
-        )
+        when (severity) {
+            Logger.Severity.Verbose -> Kermit.v(tag, throwable, message)
+            Logger.Severity.Debug -> Kermit.d(tag, throwable, message)
+            Logger.Severity.Info -> Kermit.i(tag, throwable, message)
+            Logger.Severity.Warn -> Kermit.w(tag, throwable, message)
+            Logger.Severity.Error -> Kermit.e(tag, throwable, message)
+            Logger.Severity.Assert -> Kermit.a(tag, throwable, message)
+        }
     }
 
     /**
@@ -34,14 +35,5 @@ object DefaultLogger : Logger {
     @Suppress("unused")
     fun disable() {
         isDisabled = true
-    }
-
-    private fun Logger.Severity.map() = when (this) {
-        Logger.Severity.Verbose -> Severity.Verbose
-        Logger.Severity.Debug -> Severity.Debug
-        Logger.Severity.Info -> Severity.Info
-        Logger.Severity.Warn -> Severity.Warn
-        Logger.Severity.Error -> Severity.Error
-        Logger.Severity.Assert -> Severity.Assert
     }
 }

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/Logger.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/Logger.kt
@@ -4,20 +4,20 @@ package io.yumemi.tart.logging
  * Interface that provides logging functionality.
  * Used for logging internal Tart operations and diagnostic information.
  */
-interface Logger {
+fun interface Logger {
     /**
      * Outputs a log with the specified severity.
      *
      * @param severity The severity of the log
      * @param tag The tag for the log
      * @param throwable Associated exception (if any)
-     * @param message The log message
+     * @param message Provider for the log message. It may not be evaluated if logging is skipped.
      */
-    suspend fun log(
+    fun log(
         severity: Severity,
         tag: String,
         throwable: Throwable?,
-        message: String,
+        message: () -> String,
     )
 
     /**

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
@@ -26,7 +26,7 @@ abstract class LoggingMiddleware<S : State, A : Action, E : Event>(
 
     protected fun log(severity: Logger.Severity, tag: String, throwable: Throwable? = null, message: () -> String) {
         middlewareScope.launch(dispatcher) { // launch Coroutines to avoid blocking Store processing in case of heavy logging
-            logger.log(severity = severity, tag = tag, throwable = throwable, message = message())
+            logger.log(severity = severity, tag = tag, throwable = throwable, message = message)
         }
     }
 }

--- a/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
+++ b/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
@@ -38,8 +38,8 @@ private sealed interface CounterAction : Action {
 
 private class TestLogger : Logger {
     val logs = mutableListOf<String>()
-    override suspend fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: String) {
-        logs.add(message)
+    override fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: () -> String) {
+        logs.add(message())
     }
 }
 


### PR DESCRIPTION
## Summary
- Change Logger to a fun interface with a lazy message lambda.
- Forward lazy messages through LoggingMiddleware and route DefaultLogger through Kermit severity-specific APIs.
- Update logging tests to match the new logger signature.

## Why
- Avoid eagerly constructing log messages before the logger decides whether to emit them.
- Keep the logging API aligned with Kermit's lazy message support.

## Verification
- ./gradlew :tart-logging:jvmTest