### PR TITLE
Add flat aliases for store launch scopes

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -321,7 +321,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 override fun launch(
                     dispatcher: CoroutineDispatcher?,
                     control: LaunchControl,
-                    block: suspend ActionScope.LaunchScope<S, A, E, S>.() -> Unit,
+                    block: suspend ActionLaunchScope<S, A, E, S>.() -> Unit,
                 ) {
                     val stateRuntime = stateRuntimes[state::class] ?: throw InternalError(IllegalStateException("[Tart] State scope is not found"))
                     launchActionInStateRuntime(
@@ -367,7 +367,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     emit(event)
                 }
 
-                override fun launch(dispatcher: CoroutineDispatcher?, block: suspend EnterScope.LaunchScope<S, E, S>.() -> Unit) {
+                override fun launch(dispatcher: CoroutineDispatcher?, block: suspend EnterLaunchScope<S, E, S>.() -> Unit) {
                     launchInStateRuntime(
                         stateRuntime = stateRuntime,
                         dispatcher = dispatcher,
@@ -498,20 +498,20 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         }
     }
 
-    private fun buildEnterLaunchScope(stateScope: CoroutineScope): EnterScope.LaunchScope<S, E, S> {
-        return object : EnterScope.LaunchScope<S, E, S> {
+    private fun buildEnterLaunchScope(stateScope: CoroutineScope): EnterLaunchScope<S, E, S> {
+        return object : EnterLaunchScope<S, E, S> {
             override val isActive: Boolean get() = stateScope.isActive
 
             override suspend fun event(event: E) {
                 emit(event)
             }
 
-            override suspend fun transaction(dispatcher: CoroutineDispatcher?, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
+            override suspend fun transaction(dispatcher: CoroutineDispatcher?, block: suspend EnterTransactionScope<S, E, S>.() -> Unit) {
                 val job = coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
                     mutex.withLock {
                         if (stateScope.isActive) {
                             var newState: S? = null
-                            val transactionScope = object : EnterScope.LaunchScope.TransactionScope<S, E, S> {
+                            val transactionScope = object : EnterTransactionScope<S, E, S> {
                                 override val state: S = currentState
 
                                 override fun nextState(state: S) {
@@ -549,8 +549,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         }
     }
 
-    private fun buildActionLaunchScope(stateScope: CoroutineScope, launchedAction: A): ActionScope.LaunchScope<S, A, E, S> {
-        return object : ActionScope.LaunchScope<S, A, E, S> {
+    private fun buildActionLaunchScope(stateScope: CoroutineScope, launchedAction: A): ActionLaunchScope<S, A, E, S> {
+        return object : ActionLaunchScope<S, A, E, S> {
             override val isActive: Boolean get() = stateScope.isActive
             override val action: A = launchedAction
 
@@ -558,12 +558,12 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 emit(event)
             }
 
-            override suspend fun transaction(dispatcher: CoroutineDispatcher?, block: suspend ActionScope.LaunchScope.TransactionScope<S, A, E, S>.() -> Unit) {
+            override suspend fun transaction(dispatcher: CoroutineDispatcher?, block: suspend ActionTransactionScope<S, A, E, S>.() -> Unit) {
                 val job = coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
                     mutex.withLock {
                         if (stateScope.isActive) {
                             var newState: S? = null
-                            val transactionScope = object : ActionScope.LaunchScope.TransactionScope<S, A, E, S> {
+                            val transactionScope = object : ActionTransactionScope<S, A, E, S> {
                                 override val state: S = currentState
                                 override val action: A = launchedAction
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -62,7 +62,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * When null, the coroutine inherits the Store's current execution context.
      * @param block The suspending block of code to execute
      */
-    fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend LaunchScope<S, E, S2>.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend EnterLaunchScope<S, E, S2>.() -> Unit)
 
     /**
      * Scope available within a launched coroutine.
@@ -93,7 +93,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
          * When null, the transaction inherits the Store's current execution context.
          * @param block The suspending block of code to execute as a transaction
          */
-        suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend TransactionScope<S, E, S2>.() -> Unit)
+        suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend EnterTransactionScope<S, E, S2>.() -> Unit)
 
         /**
          * Scope available within a transaction operation.
@@ -143,6 +143,18 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         }
     }
 }
+
+/**
+ * Flattened alias for [EnterScope.LaunchScope] to keep public signatures concise in IDE tooltips.
+ *
+ * `S2` remains because it carries the narrowed state type through to the transaction scope's `state`.
+ */
+typealias EnterLaunchScope<S, E, S2> = EnterScope.LaunchScope<S, E, S2>
+
+/**
+ * Flattened alias for [EnterScope.LaunchScope.TransactionScope] to keep public signatures concise in IDE tooltips.
+ */
+typealias EnterTransactionScope<S, E, S2> = EnterScope.LaunchScope.TransactionScope<S, E, S2>
 
 /**
  * Scope available when a state is being exited.
@@ -241,7 +253,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * may use an explicit [LaunchLane] or the action-local default lane.
      * @param block The suspending block of code to execute
      */
-    fun launch(dispatcher: CoroutineDispatcher? = null, control: LaunchControl = LaunchControl.Concurrent, block: suspend LaunchScope<S, A, E, S2>.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher? = null, control: LaunchControl = LaunchControl.Concurrent, block: suspend ActionLaunchScope<S, A, E, S2>.() -> Unit)
 
     /**
      * Scope available within a launched coroutine from an action handler.
@@ -277,7 +289,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
          * When null, the transaction inherits the Store's current execution context.
          * @param block The suspending block of code to execute as a transaction
          */
-        suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend TransactionScope<S, A, E, S2>.() -> Unit)
+        suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend ActionTransactionScope<S, A, E, S2>.() -> Unit)
 
         /**
          * Scope available within a transaction operation.
@@ -332,6 +344,18 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         }
     }
 }
+
+/**
+ * Flattened alias for [ActionScope.LaunchScope] to keep public signatures concise in IDE tooltips.
+ *
+ * `S2` remains because it carries the narrowed state type through to the transaction scope's `state`.
+ */
+typealias ActionLaunchScope<S, A, E, S2> = ActionScope.LaunchScope<S, A, E, S2>
+
+/**
+ * Flattened alias for [ActionScope.LaunchScope.TransactionScope] to keep public signatures concise in IDE tooltips.
+ */
+typealias ActionTransactionScope<S, A, E, S2> = ActionScope.LaunchScope.TransactionScope<S, A, E, S2>
 
 /**
  * Scope available when an error occurs in a state handler.


### PR DESCRIPTION
## Summary
- add flat public type aliases for enter/action launch and transaction scopes
- update StoreScope signatures and StoreImpl references to use the aliases
- keep `S2` because it still carries narrowed state typing into transaction scope state

## Why
- reduce IDE hover, error, and KDoc noise from deeply nested scope type names
- improve API readability without changing behavior

## Verification
- ./gradlew :tart-core:jvmTest