### PR TITLE
Refine store scope and observer generics

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -96,12 +96,12 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         val handler: suspend SC.() -> Unit,
     )
 
-    val registeredEnterHandlers = mutableListOf<StateHandler<(S) -> Boolean, EnterScope<S, A, E, S>>>()
+    val registeredEnterHandlers = mutableListOf<StateHandler<(S) -> Boolean, EnterScope<S, E, S>>>()
     val registeredActionHandlers = mutableListOf<StateHandler<(S, A) -> Boolean, ActionScope<S, A, E, S>>>()
     val registeredExitHandlers = mutableListOf<StateHandler<(S) -> Boolean, ExitScope<S, E, S>>>()
     val registeredErrorHandlers = mutableListOf<StateHandler<(S, Throwable) -> Boolean, ErrorScope<S, E, S, Throwable>>>()
 
-    private val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit = {
+    private val onEnter: suspend EnterScope<S, E, S>.() -> Unit = {
         val matchingHandler = this@StoreBuilder.registeredEnterHandlers.firstOrNull { it.predicate(state) }
         matchingHandler?.handler?.invoke(this) ?: state
     }
@@ -140,7 +140,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             }
         }
 
-        val stateEnterHandlers = mutableListOf<ThreadedHandler<Nothing?, EnterScope<S, A, E, S2>>>()
+        val stateEnterHandlers = mutableListOf<ThreadedHandler<Nothing?, EnterScope<S, E, S2>>>()
         val stateActionHandlers = mutableListOf<ThreadedHandler<(A) -> Boolean, ActionScope<S, A, E, S2>>>()
         val stateExitHandlers = mutableListOf<ThreadedHandler<Nothing?, ExitScope<S, E, S2>>>()
         val stateErrorHandlers = mutableListOf<ThreadedHandler<(Throwable) -> Boolean, ErrorScope<S, E, S2, Throwable>>>()
@@ -154,7 +154,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
          * @param dispatcher Optional CoroutineDispatcher override for executing the enter handler
          * @param block The handler function that will be executed when entering this state
          */
-        fun enter(dispatcher: CoroutineDispatcher? = null, block: suspend EnterScope<S, A, E, S2>.() -> Unit) {
+        fun enter(dispatcher: CoroutineDispatcher? = null, block: suspend EnterScope<S, E, S2>.() -> Unit) {
             stateEnterHandlers.add(ThreadedHandler(dispatcher, null, block))
         }
 
@@ -236,7 +236,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
                     predicate = { it is S2 },
                     handler = {
                         @Suppress("UNCHECKED_CAST")
-                        enterHandler.invoke(this as EnterScope<S, A, E, S2>)
+                        enterHandler.invoke(this as EnterScope<S, E, S2>)
                     },
                 ),
             )
@@ -290,7 +290,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
             override val middlewareExecutionPolicy: MiddlewareExecutionPolicy = storeMiddlewareExecutionPolicy
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
-            override val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onEnter
+            override val onEnter: suspend EnterScope<S, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
             override val onExit: suspend ExitScope<S, E, S>.() -> Unit = this@StoreBuilder.onExit
             override val onError: suspend ErrorScope<S, E, S, Throwable>.() -> Unit = this@StoreBuilder.onError

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -76,7 +76,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val middlewares: List<Middleware<S, A, E>>
 
-    protected abstract val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit
+    protected abstract val onEnter: suspend EnterScope<S, E, S>.() -> Unit
 
     protected abstract val onAction: suspend ActionScope<S, A, E, S>.() -> Unit
 
@@ -349,7 +349,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         stateRuntimes[state::class] = stateRuntime
         var newState: S? = null
         onEnter.invoke(
-            object : EnterScope<S, A, E, S> {
+            object : EnterScope<S, E, S> {
                 override val state = state
                 override fun nextState(state: S) {
                     newState = state

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreInternalApi.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreInternalApi.kt
@@ -6,7 +6,7 @@ package io.yumemi.tart.core
  * For most test cases, prefer `StoreRecorder` or `createRecorder()` from `:tart-test`.
  * Implement this interface when you need custom recording or observation behavior.
  */
-interface StoreObserver<S : State, E : Event> {
+interface StoreObserver<in S : State, in E : Event> {
     /**
      * Called when the Store exposes a state snapshot to observers.
      *

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -13,7 +13,7 @@ sealed interface StoreScope
  * Used in enter handlers to manage state transitions and side effects.
  */
 @TartStoreDsl
-interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
+interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
     /**
      * The current state snapshot when this handler is executing.
      * This value does not change immediately when [nextState] or [nextStateBy] is called.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
@@ -87,6 +87,36 @@ class StoreObserverTest {
     }
 
     @Test
+    fun attachObserver_acceptsObserverOfBroaderTypes() = runTest(testDispatcher) {
+        val store = createTestStore()
+        val observedStates = mutableListOf<State>()
+        val observedEvents = mutableListOf<Event>()
+        val observer: StoreObserver<State, Event> = object : StoreObserver<State, Event> {
+            override fun onState(state: State) {
+                observedStates.add(state)
+            }
+
+            override fun onEvent(event: Event) {
+                observedEvents.add(event)
+            }
+        }
+
+        store.attachObserverForTest(observer)
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.EmitEvent)
+
+        assertEquals(
+            listOf<State>(
+                AppState.Loading,
+                AppState.Main(count = 0),
+                AppState.Main(count = 1),
+            ),
+            observedStates,
+        )
+        assertEquals(listOf<Event>(AppEvent.CountUpdated(count = 1)), observedEvents)
+    }
+
+    @Test
     fun attachObserver_isAllowedAfterCollectingEventsBeforeStart() = runTest(testDispatcher) {
         val store = createTestStore()
         val history = ObservationHistory<AppState, AppEvent>()


### PR DESCRIPTION
## Summary
- add flat public aliases for launch and transaction scopes used by enter and action handlers
- simplify `EnterScope` by removing its unused action type parameter
- widen `StoreObserver` variance and add a test that broader observer types can be attached

## Why
- reduce generic noise in public scope signatures and IDE tooltips
- remove an unused generic from `EnterScope` while preserving behavior
- make observer typing more flexible without narrowing future middleware design

## Verification
- ./gradlew :tart-core:jvmTest
- ./gradlew :tart-core:jvmTest :tart-test:jvmTest :tart-message:jvmTest :tart-logging:jvmTest :tart-compose:jvmTest