### PR TITLE
Restrict error DSL to Exception recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 }
 ```
 
-This works, but you can also handle errors with the `error{}` block.
+This works, but you can also handle exceptions with the `error{}` block.
 
 ```kt
 val store: Store<CounterState, CounterAction, CounterEvent> = Store {
@@ -419,10 +419,10 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 }
 ```
 
-Errors can be caught not only in the `enter{}` block but also in the `action{}` and `exit{}` blocks.
-In other words, your business logic errors can be handled in the `error{}` block.
+Exceptions can be caught not only in the `enter{}` block but also in the `action{}` and `exit{}` blocks.
+In other words, your business logic exceptions can be handled in the `error{}` block.
 
-On the other hand, uncaught errors in the entire Store (such as system errors) can be handled with the `exceptionHandler()` specification:
+On the other hand, fatal errors and other uncaught non-`Exception` throwables in the entire Store can be handled with the `exceptionHandler()` specification:
 
 ```kt
 val store: Store<CounterState, CounterAction, CounterEvent> = Store {

--- a/doc/internal/adr/2026-05-01-error-dsl-exception-boundary.md
+++ b/doc/internal/adr/2026-05-01-error-dsl-exception-boundary.md
@@ -1,0 +1,50 @@
+# `error {}` DSL は `Exception` の回復経路に限定する
+
+- 更新日: 2026-05-01
+
+## 背景
+
+Tart の `error {}` DSL は、state machine の中で発生した失敗を state 遷移として扱うための入口である。
+一方で Kotlin の `Throwable` には、通常の業務例外として回復を試みるべき `Exception` だけでなく、`AssertionError` などの `Error` 系や、独自 `Throwable` のような非標準の失敗も含まれる。
+
+これまでの実装では、fatal として即再送出していたものを除き、広く `Throwable` を `error {}` 側へ流しうる形になっていた。
+しかしこの形だと、次の境界が曖昧になる。
+
+- `error {}` が回復対象として扱う失敗
+- `exceptionHandler()` が最後の受け皿として扱う失敗
+- coroutine / job として成功完了にしてよい失敗
+- job failure として扱うべき失敗
+
+また、公開 DSL の型境界を `Throwable` のまま保つと、利用者からは「どの `Throwable` まで回復対象なのか」が読み取りにくい。
+
+## 決定
+
+`error {}` DSL は、`Exception` を回復するための経路に限定する。
+
+- `error<T>` の `T` は `Exception` のみを受け付ける
+- `ErrorScope.error` の型も `Exception` に限定する
+- Store 内の recoverable path は `Exception` のみを `error {}` に流す
+- `Exception` ではない `Throwable` は recoverable とみなさず、job failure として扱う
+- `Exception` ではない `Throwable` は `exceptionHandler()` に流れるが、`error {}` には入れない
+- middleware / observer / persistence など framework boundary で発生した `Exception` も、`error {}` の回復対象には入れない
+
+この判断により、意味づけは次のように固定する。
+
+- `error {}` は recovery path
+- `exceptionHandler()` は last-resort path
+- `error {}` で処理できた失敗は、Store work としては成功完了でよい
+- `error {}` に乗らない失敗は、未回復のまま success 扱いにしない
+
+## 補足
+
+- `CancellationException` は `Exception` ではあるが、coroutine cancellation の制御信号でもあるため、通常の recovery 対象には入れない。
+- したがって runtime 上は、「`Exception` なら常に recoverable」ではなく、「recoverable exception path へ流してよい `Exception` だけを対象にする」という整理になる。
+- recoverable / non-recoverable の境界は型だけでは決まらない。state handler や launched `transaction {}` の中で投げられた `Exception` は recovery path に流すが、middleware hook、observer callback、`stateSaver.save()` など framework boundary で投げられた `Exception` は recovery path に再投入しない。
+- そのため実装では、framework boundary で起きた `Exception` を `InternalError` で包み、`error {}` に再突入しないようにしている。`exceptionHandler()` に渡す直前には unwrap して、利用者には元の `Exception` を見せる。
+- `action {}` / `enter {}` / `exit {}` / launched `transaction {}` の中では、利用者は Kotlin の言語仕様上 `throw Throwable(...)` を書ける。この点は API 上の違和感になりうるため、README / KDoc では `error {}` が `Exception` 専用の recovery path であることを明示する。
+- この判断は source-compatible ではない。既存の `error<Throwable> { ... }` や custom `Throwable` を回復対象にしていたコードは移行が必要になる。
+- 本メモは、Store の通常 runtime path における error handling 境界を対象とする。起動時の state restore など、`_state` 初期化まわりの個別事情はここでは扱わない。
+
+## 関連
+
+- [Tart の設計原則](../design/2026-04-23-design-principles.md)

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -99,7 +99,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     val registeredEnterHandlers = mutableListOf<StateHandler<(S) -> Boolean, EnterScope<S, E, S>>>()
     val registeredActionHandlers = mutableListOf<StateHandler<(S, A) -> Boolean, ActionScope<S, A, E, S>>>()
     val registeredExitHandlers = mutableListOf<StateHandler<(S) -> Boolean, ExitScope<S, E, S>>>()
-    val registeredErrorHandlers = mutableListOf<StateHandler<(S, Throwable) -> Boolean, ErrorScope<S, E, S, Throwable>>>()
+    val registeredErrorHandlers = mutableListOf<StateHandler<(S, Exception) -> Boolean, ErrorScope<S, E, S, Exception>>>()
 
     private val onEnter: suspend EnterScope<S, E, S>.() -> Unit = {
         val matchingHandler = this@StoreBuilder.registeredEnterHandlers.firstOrNull { it.predicate(state) }
@@ -116,7 +116,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         matchingHandler?.handler?.invoke(this)
     }
 
-    private val onError: suspend ErrorScope<S, E, S, Throwable>.() -> Unit = {
+    private val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit = {
         val matchingHandler = this@StoreBuilder.registeredErrorHandlers.firstOrNull { it.predicate(state, error) }
         matchingHandler?.handler?.invoke(this) ?: throw error
     }
@@ -143,7 +143,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         val stateEnterHandlers = mutableListOf<ThreadedHandler<Nothing?, EnterScope<S, E, S2>>>()
         val stateActionHandlers = mutableListOf<ThreadedHandler<(A) -> Boolean, ActionScope<S, A, E, S2>>>()
         val stateExitHandlers = mutableListOf<ThreadedHandler<Nothing?, ExitScope<S, E, S2>>>()
-        val stateErrorHandlers = mutableListOf<ThreadedHandler<(Throwable) -> Boolean, ErrorScope<S, E, S2, Throwable>>>()
+        val stateErrorHandlers = mutableListOf<ThreadedHandler<(Exception) -> Boolean, ErrorScope<S, E, S2, Exception>>>()
 
         /**
          * Registers a handler to be invoked when entering this state with the specified CoroutineDispatcher.
@@ -195,7 +195,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         }
 
         /**
-         * Registers a handler for a specific error type in the current state configuration
+         * Registers a handler for a specific exception type in the current state configuration
          * with an optional CoroutineDispatcher.
          * If multiple `error {}` handlers can match the current state and error,
          * the first registered handler is used.
@@ -204,7 +204,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
          * @param dispatcher Optional CoroutineDispatcher override for executing the error handler
          * @param block The handler function that processes the error and updates the state
          */
-        inline fun <reified T : Throwable> error(dispatcher: CoroutineDispatcher? = null, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
+        inline fun <reified T : Exception> error(dispatcher: CoroutineDispatcher? = null, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
             stateErrorHandlers.add(
                 ThreadedHandler(
                     dispatcher = dispatcher,
@@ -272,7 +272,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
                     predicate = { state, throwable -> state is S2 && errorHandler.predicate(throwable) },
                     handler = {
                         @Suppress("UNCHECKED_CAST")
-                        errorHandler.invoke(this as ErrorScope<S, E, S2, Throwable>)
+                        errorHandler.invoke(this as ErrorScope<S, E, S2, Exception>)
                     },
                 ),
             )
@@ -293,7 +293,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val onEnter: suspend EnterScope<S, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
             override val onExit: suspend ExitScope<S, E, S>.() -> Unit = this@StoreBuilder.onExit
-            override val onError: suspend ErrorScope<S, E, S, Throwable>.() -> Unit = this@StoreBuilder.onError
+            override val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit = this@StoreBuilder.onError
         }
     }
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -33,7 +33,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 stateSaver.restore() ?: initialState
             } catch (t: Throwable) {
                 handleException(t)
-                initialState
+                if (t is Exception) {
+                    initialState
+                } else {
+                    throw t
+                }
             },
         )
     }
@@ -82,7 +86,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val onExit: suspend ExitScope<S, E, S>.() -> Unit
 
-    protected abstract val onError: suspend ErrorScope<S, E, S, Throwable>.() -> Unit
+    protected abstract val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit
 
     private val coroutineScope by lazy {
         CoroutineScope(
@@ -212,8 +216,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 onStateEntered(nextState)
             }
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
-            onErrorOccurred(currentState, t)
+            rethrowIfNonRecoverable(t)
+            onErrorOccurred(currentState, t as Exception)
         }
     }
 
@@ -234,8 +238,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 onStateEntered(nextState)
             }
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
-            onErrorOccurred(currentState, t)
+            rethrowIfNonRecoverable(t)
+            onErrorOccurred(currentState, t as Exception)
         }
     }
 
@@ -258,17 +262,17 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 onStateEntered(nextState, inErrorHandling = inErrorHandling)
             }
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
+            rethrowIfNonRecoverable(t)
             if (inErrorHandling) {
                 throw InternalError(t)
             }
-            onErrorOccurred(currentState, t)
+            onErrorOccurred(currentState, t as Exception)
         }
     }
 
-    private suspend fun onErrorOccurred(state: S, throwable: Throwable) {
+    private suspend fun onErrorOccurred(state: S, exception: Exception) {
         try {
-            val nextState = processError(state, throwable)
+            val nextState = processError(state, exception)
 
             if (state::class != nextState::class) {
                 processStateExit(state)
@@ -285,7 +289,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 onStateEntered(nextState, inErrorHandling = true)
             }
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
+            rethrowIfNonRecoverable(t)
             throw InternalError(t)
         }
     }
@@ -487,11 +491,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         try {
             block(launchScope)
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
+            rethrowIfNonRecoverable(t)
             coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
                 mutex.withLock {
                     if (stateRuntime.scope.isActive) {
-                        onErrorOccurred(currentState, t)
+                        onErrorOccurred(currentState, t as Exception)
                     }
                 }
             }
@@ -533,8 +537,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                             try {
                                 block(transactionScope)
                             } catch (t: Throwable) {
-                                rethrowIfFatal(t)
-                                onErrorOccurred(currentState, t)
+                                rethrowIfNonRecoverable(t)
+                                onErrorOccurred(currentState, t as Exception)
                                 return@withLock
                             }
                             val nextState = newState ?: currentState
@@ -586,8 +590,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                             try {
                                 block(transactionScope)
                             } catch (t: Throwable) {
-                                rethrowIfFatal(t)
-                                onErrorOccurred(currentState, t)
+                                rethrowIfNonRecoverable(t)
+                                onErrorOccurred(currentState, t as Exception)
                                 return@withLock
                             }
                             val nextState = newState ?: currentState
@@ -631,18 +635,18 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         try {
             stateSaver.save(nextState)
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
+            rethrowIfNonRecoverable(t)
             throw InternalError(t)
         }
         notifyStateRecorded(nextState)
         processMiddleware { afterStateChange(nextState, state) }
     }
 
-    private suspend fun processError(state: S, throwable: Throwable): S {
+    private suspend fun processError(state: S, throwable: Exception): S {
         processMiddleware { beforeError(state, throwable) }
         var newState: S? = null
         onError.invoke(
-            object : ErrorScope<S, E, S, Throwable> {
+            object : ErrorScope<S, E, S, Exception> {
                 override val state = state
                 override val error = throwable
                 override fun nextState(state: S) {
@@ -702,7 +706,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 }
             }
         } catch (t: Throwable) {
-            rethrowIfFatal(t)
+            rethrowIfNonRecoverable(t)
             throw InternalError(t)
         }
     }
@@ -712,7 +716,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             try {
                 observer.onState(state)
             } catch (t: Throwable) {
-                rethrowIfFatal(t)
+                rethrowIfNonRecoverable(t)
                 throw InternalError(t)
             }
         }
@@ -723,7 +727,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             try {
                 observer.onEvent(event)
             } catch (t: Throwable) {
-                rethrowIfFatal(t)
+                rethrowIfNonRecoverable(t)
                 throw InternalError(t)
             }
         }
@@ -734,8 +738,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         exceptionHandler.handle(handled)
     }
 
-    private fun rethrowIfFatal(t: Throwable) {
-        if (t is CancellationException || t is Error || t is InternalError) {
+    private fun rethrowIfNonRecoverable(t: Throwable) {
+        if (t is CancellationException || t !is Exception) {
             throw t
         }
     }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -358,11 +358,11 @@ typealias ActionLaunchScope<S, A, E, S2> = ActionScope.LaunchScope<S, A, E, S2>
 typealias ActionTransactionScope<S, A, E, S2> = ActionScope.LaunchScope.TransactionScope<S, A, E, S2>
 
 /**
- * Scope available when an error occurs in a state handler.
- * Used in error handlers to recover from errors or update state accordingly.
+ * Scope available when an exception occurs in a state handler.
+ * Used in error handlers to recover from exceptions or update state accordingly.
  */
 @TartStoreDsl
-interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
+interface ErrorScope<S : State, E : Event, S2 : S, T : Exception> : StoreScope {
     /**
      * The current state snapshot when this handler is executing.
      * This value does not change immediately when [nextState] or [nextStateBy] is called.
@@ -370,7 +370,7 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     val state: S2
 
     /**
-     * The error that occurred
+     * The exception that occurred
      */
     val error: T
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
@@ -16,6 +16,7 @@ import kotlin.test.assertTrue
 class StoreActionCoroutineScopeTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
+    private class DirectThrowable(message: String) : Throwable(message)
 
     sealed interface AppState : State {
         data class Active(val value: Int = 0) : AppState
@@ -33,6 +34,7 @@ class StoreActionCoroutineScopeTest {
         data object LaunchTransactionThrow : AppAction
         data object LaunchFatal : AppAction
         data object LaunchTransactionFatal : AppAction
+        data object LaunchBareThrowable : AppAction
     }
 
     private fun createTestStore(
@@ -98,6 +100,12 @@ class StoreActionCoroutineScopeTest {
                     }
                 }
 
+                action<AppAction.LaunchBareThrowable> {
+                    launch {
+                        throw DirectThrowable("bare throwable")
+                    }
+                }
+
                 action<AppAction.LaunchTransactionThrow> {
                     launch {
                         transaction {
@@ -116,7 +124,7 @@ class StoreActionCoroutineScopeTest {
             }
 
             state<AppState> {
-                error<Throwable> {
+                error<Exception> {
                     nextState(AppState.Failed(error.message ?: "unknown"))
                 }
             }
@@ -207,6 +215,23 @@ class StoreActionCoroutineScopeTest {
         val error = handledThrowable
         assertIs<AssertionError>(error)
         assertEquals("fatal launch", error.message)
+        assertEquals(AppState.Active(value = 0), store.currentState)
+    }
+
+    @Test
+    fun actionLaunch_nonExceptionThrowable_isForwardedToExceptionHandler() = runTest(testDispatcher) {
+        var handledThrowable: Throwable? = null
+        val store = createTestStore(
+            exceptionHandler = ExceptionHandler { handledThrowable = it },
+        )
+
+        store.dispatch(AppAction.LaunchBareThrowable)
+        repeat(3) { yield() }
+
+        assertNotNull(handledThrowable)
+        val error = handledThrowable
+        assertIs<DirectThrowable>(error)
+        assertEquals("bare throwable", error.message)
         assertEquals(AppState.Active(value = 0), store.currentState)
     }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreMiddlewareExceptionTest.kt
@@ -1,0 +1,92 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreMiddlewareExceptionTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    sealed interface AppState : State {
+        data class Ready(val value: Int = 0) : AppState
+        data class Failed(val message: String) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object Throw : AppAction
+    }
+
+    private fun createStore(
+        middleware: Middleware<AppState, AppAction, Nothing>,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(AppState.Ready()) {
+            coroutineContext(Dispatchers.Unconfined)
+            exceptionHandler(exceptionHandler)
+            middleware(middleware)
+
+            state<AppState.Ready> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(value = state.value + 1))
+                }
+
+                action<AppAction.Throw> {
+                    throw IllegalStateException("action failed")
+                }
+            }
+
+            state<AppState> {
+                error<Exception> {
+                    nextState(AppState.Failed(error.message ?: "unknown"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun middlewareException_isHandledWithoutUsingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createStore(
+            middleware = Middleware(
+                beforeActionDispatch = { _, _ ->
+                    throw IllegalArgumentException("middleware failed")
+                },
+            ),
+            exceptionHandler = ExceptionHandler { handledException = it },
+        )
+
+        store.dispatch(AppAction.Increment)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Ready(), store.currentState)
+        val error = assertIs<IllegalArgumentException>(handledException)
+        assertEquals("middleware failed", error.message)
+    }
+
+    @Test
+    fun middlewareBeforeErrorException_isHandledWithoutRetryingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createStore(
+            middleware = Middleware(
+                beforeError = { _, _ ->
+                    throw IllegalArgumentException("beforeError failed")
+                },
+            ),
+            exceptionHandler = ExceptionHandler { handledException = it },
+        )
+
+        store.dispatch(AppAction.Throw)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Ready(), store.currentState)
+        val error = assertIs<IllegalArgumentException>(handledException)
+        assertEquals("beforeError failed", error.message)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreObserverTest.kt
@@ -327,7 +327,7 @@ class StoreObserverTest {
 
             if (errorStateOnException != null) {
                 state<AppState> {
-                    error<Throwable> {
+                    error<Exception> {
                         nextState(errorStateOnException)
                     }
                 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class StoreSaverTest {
@@ -20,13 +21,21 @@ class StoreSaverTest {
     private fun createTestStore(
         initialState: AppState,
         stateSaver: StateSaver<AppState>,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+        errorStateOnException: AppState? = null,
     ): Store<AppState, AppAction, Nothing> {
         return Store(initialState) {
             coroutineContext(Dispatchers.Unconfined)
             stateSaver(stateSaver)
+            exceptionHandler(exceptionHandler)
             state<AppState> {
                 action<AppAction.Update> {
                     nextState(state.copy(value = action.value))
+                }
+                if (errorStateOnException != null) {
+                    error<Exception> {
+                        nextState(errorStateOnException)
+                    }
                 }
             }
         }
@@ -48,5 +57,26 @@ class StoreSaverTest {
         store.dispatch(AppAction.Update(20))
 
         assertEquals(AppState(20), savedState)
+    }
+
+    @Test
+    fun store_saveException_isHandledWithoutUsingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createTestStore(
+            initialState = AppState(0),
+            stateSaver = StateSaver(
+                save = { throw IllegalArgumentException("save failed") },
+                restore = { null },
+            ),
+            exceptionHandler = ExceptionHandler { handledException = it },
+            errorStateOnException = AppState(-1),
+        )
+
+        store.dispatch(AppAction.Update(20))
+        testScheduler.runCurrent()
+
+        assertEquals(AppState(20), store.currentState)
+        val error = assertIs<IllegalArgumentException>(handledException)
+        assertEquals("save failed", error.message)
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -197,7 +197,7 @@ class StoreStateCoroutineScopeTest {
             }
 
             state<AppState> {
-                error<Throwable> {
+                error<Exception> {
                     nextState(AppState.Failed(error.message ?: "unknown"))
                 }
             }


### PR DESCRIPTION
## Summary
- Restrict the Store error DSL and ErrorScope to Exception-based recovery.
- Treat non-recoverable throwables and framework-boundary exceptions as exceptionHandler-only paths.
- Add regression tests for non-Exception throwables, middleware exceptions, and state saver save exceptions.
- Add an internal ADR documenting the recovery boundary and InternalError wrapping.

## Why
- Align the public error DSL contract with the runtime recovery boundary.
- Keep business exception recovery separate from framework and execution failures.

## Verification
- ./gradlew :tart-core:jvmTest