### PR TITLE
Refine public API KDoc

### DIFF
--- a/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/StateSaver.kt
+++ b/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/StateSaver.kt
@@ -18,10 +18,12 @@ private class StateSaverImpl<S : State> : StateSaver<S> {
 }
 
 /**
- * Creates and remembers a StateSaver instance that persists across recompositions.
- * This implementation is retained in memory and suitable for use with Compose.
+ * Remembers an in-memory [StateSaver] that survives recomposition.
  *
- * @return A StateSaver instance for preserving state
+ * This saver is retained in memory via `rememberRetained` and is intended for Compose-driven
+ * state restoration.
+ *
+ * @return A [StateSaver] for preserving state snapshots in Compose
  */
 @Suppress("unused")
 @Composable

--- a/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
+++ b/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
@@ -16,12 +16,13 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 
 /**
- * Store wrapper class for use with Compose UI.
- * Provides state, action dispatching, and event handling.
+ * Compose-friendly wrapper around a [Store] snapshot.
+ *
+ * It exposes the latest state, a dispatch function, and access to the Store's event stream.
  *
  * @param state The current state
  * @param dispatch Function to dispatch actions
- * @param eventFlow Flow to receive events
+ * @param eventFlow Flow used to receive one-off events
  */
 @Suppress("unused")
 @Stable
@@ -41,9 +42,11 @@ class ViewStore<S : State, A : Action, E : Event>(
     }
 
     /**
-     * Renders UI for a state of a specified type.
+     * Invokes [block] only when the current [state] is of type [S2].
      *
-     * @param block Composable function to perform rendering
+     * Inside [block], this [ViewStore] is narrowed to [S2].
+     *
+     * @param block Composable function to render the narrowed state
      */
     @Suppress("ComposableNaming")
     @Composable
@@ -55,10 +58,9 @@ class ViewStore<S : State, A : Action, E : Event>(
     }
 
     /**
-     * Handles events of a specified type.
+     * Collects only events of type [E2] while this composable is in the composition.
      *
-     * This collects events after the composable enters the composition.
-     * It receives only events emitted while this handler is actively collecting.
+     * Collection starts after the composable enters the composition.
      * Events emitted earlier are not replayed.
      *
      * @param block Function to process the event
@@ -75,13 +77,14 @@ class ViewStore<S : State, A : Action, E : Event>(
 }
 
 /**
- * Composable function that creates and returns a new ViewStore instance from a Store.
- * Monitors state changes in the Store and triggers UI redrawing.
+ * Remembers a [Store], collects its state as Compose state, and exposes it as a [ViewStore].
  *
- * This starts collecting [Store.state] immediately, so it can start the Store before any
- * [ViewStore.handle] collector begins observing events.
- * As a result, startup events such as events emitted from initial `enter {}` processing
- * may be emitted before handlers in the same composition start collecting them.
+ * Collecting [Store.state] starts the Store immediately.
+ * Because [ViewStore.handle] starts collecting later from a [LaunchedEffect], startup events such
+ * as events emitted from an initial `enter {}` handler may be emitted before handlers in the same
+ * composition begin observing them.
+ *
+ * The [store] lambda is used only when a new remembered Store must be created for [key].
  *
  * @param key Key used to remember and retain the Store instance
  * @param autoClose Whether to close the Store when the composable leaves the composition

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Contract.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Contract.kt
@@ -1,19 +1,18 @@
 package io.yumemi.tart.core
 
 /**
- * Marker interface representing state managed by the Tart framework.
- * Data classes representing application state must implement this interface.
+ * Marker interface for state snapshots managed by a Tart [Store].
  */
 interface State
 
 /**
- * Marker interface representing actions such as user interactions or external events.
- * Actions are dispatched to a Store and trigger state changes.
+ * Marker interface for inputs dispatched to a Tart [Store], such as user intents or external signals.
  */
 interface Action
 
 /**
- * Marker interface representing events to be notified to the UI.
- * Events are emitted from a Store and are one-time notifications to be processed once.
+ * Marker interface for one-off outputs emitted from a Tart [Store].
+ *
+ * Unlike [State], events are not retained as the Store's current snapshot.
  */
 interface Event

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
@@ -1,12 +1,14 @@
 package io.yumemi.tart.core
 
 /**
- * Interface for handling exceptions that occur in a Store.
- * Exceptions that occur during Store operation are processed by this handler.
+ * Handles non-fatal exceptions raised while a Store is running.
+ *
+ * This includes exceptions from DSL handlers, middleware, launched coroutines, and state
+ * persistence callbacks.
  */
 interface ExceptionHandler {
     /**
-     * Handles the occurred exception.
+     * Handles the exception after Tart unwraps its internal bookkeeping errors.
      *
      * @param error The exception to handle
      */
@@ -15,18 +17,14 @@ interface ExceptionHandler {
     @Suppress("unused")
     companion object {
         /**
-         * No-op implementation of ExceptionHandler that silently ignores all exceptions.
-         *
-         * @return An ExceptionHandler instance that ignores all exceptions
+         * Ignores all handled exceptions.
          */
         val Noop: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {}
         }
 
         /**
-         * Logging implementation of ExceptionHandler that prints exceptions to standard output.
-         *
-         * @return An ExceptionHandler instance that logs exceptions to standard output
+         * Prints the exception message and stack trace for debugging.
          */
         val Log: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {
@@ -36,9 +34,7 @@ interface ExceptionHandler {
         }
 
         /**
-         * Implementation of ExceptionHandler that leaves exceptions unhandled by rethrowing them.
-         *
-         * @return An ExceptionHandler instance that rethrows all exceptions
+         * Rethrows handled exceptions instead of swallowing them.
          */
         val Unhandled: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {
@@ -49,10 +45,7 @@ interface ExceptionHandler {
 }
 
 /**
- * Factory function to easily create an instance of ExceptionHandler.
- *
- * @param block Callback function to handle exceptions
- * @return A new ExceptionHandler instance
+ * Creates an [ExceptionHandler] from a single callback.
  */
 fun ExceptionHandler(block: (Throwable) -> Unit) = object : ExceptionHandler {
     override fun handle(error: Throwable) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
@@ -1,37 +1,35 @@
 package io.yumemi.tart.core
 
 /**
- * Stable token used to coordinate tracked coroutines launched from `action {}`.
+ * Stable key for coordinating tracked coroutines launched from `action {}` handlers.
  *
- * Reuse the same instance when multiple launches should share a lane or when the
- * lane should be cancellable via `cancelLaunch(...)`.
+ * Reuse the same instance when multiple launches should share cancellation or drop behavior, or
+ * when the lane should be cancellable later via `cancelLaunch(...)`.
  */
 class LaunchLane
 
 /**
- * Controls how coroutines launched from an `action {}` handler coordinate with
- * previous work from the same action lane.
+ * Controls how `action {}` launches coordinate with other tracked launches in the same lane.
  *
  * [Concurrent] launches are not tracked by lane.
- * [Replace] and [DropNew] create tracked lanes. When [LaunchLane] is omitted,
- * the launch uses an internal default lane that is fixed for the current
- * `action {}` block.
+ * [Replace] and [DropNew] create tracked lanes. When [LaunchLane] is omitted, the launch uses a
+ * default lane derived from the current action type, so matching launches coordinate across
+ * dispatches of that action type.
  */
 sealed interface LaunchControl {
 
     /**
-     * Launch every asynchronous handler invocation concurrently.
+     * Launch every invocation independently without lane tracking.
      */
     data object Concurrent : LaunchControl
 
     /**
-     * Cancel the previous tracked asynchronous job in the same lane before
-     * starting a new one.
+     * Cancel the previous tracked launch in the same lane before starting a new one.
      */
     data class Replace(val lane: LaunchLane? = null) : LaunchControl
 
     /**
-     * Ignore new launches while tracked work in the same lane is still active.
+     * Ignore a new launch while tracked work in the same lane is still active.
      */
     data class DropNew(val lane: LaunchLane? = null) : LaunchControl
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
@@ -1,27 +1,26 @@
 package io.yumemi.tart.core
 
 /**
- * Interface for intercepting Store lifecycle events.
- * By implementing Middleware, you can insert processing at various lifecycle points
- * such as action dispatch, state changes, event emission, etc.
+ * Intercepts Store lifecycle milestones such as startup, action handling, state transitions,
+ * event emission, and error handling.
  *
- * Middleware hooks are suspending functions and are awaited by the Store.
- * Long-running work in a hook can delay Store startup, action handling, state transitions,
- * event emission, and error processing.
+ * Middleware hooks are suspending functions and are awaited by the Store according to
+ * [MiddlewareExecutionPolicy]. Long-running work in a hook can delay startup, action handling,
+ * state transitions, event emission, and error processing.
  * When work should continue in the background, start it from [onStart] or another hook using
  * [MiddlewareScope.launch].
  */
 interface Middleware<S : State, A : Action, E : Event> {
     /**
-     * Lifecycle method called when the store is started.
+     * Called once when the Store starts, before the initial `enter {}` processing runs.
      *
-     * @param middlewareScope The scope that provides access to store functionality
+     * @param middlewareScope Scope for dispatching actions or launching Store-scoped work
      * @param state The current state
      */
     suspend fun onStart(middlewareScope: MiddlewareScope<A>, state: S) {}
 
     /**
-     * Called before an action is dispatched.
+     * Called before an action handler starts processing the dispatched action.
      *
      * @param state The current state
      * @param action The action being dispatched
@@ -29,16 +28,18 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun beforeActionDispatch(state: S, action: A) {}
 
     /**
-     * Called after an action is dispatched.
+     * Called after the matching action handler finishes and its next state is determined.
+     *
+     * This runs before any resulting state exit, state change, or state enter processing occurs.
      *
      * @param state The original state
      * @param action The dispatched action
-     * @param nextState The new state after action processing
+     * @param nextState The next state produced by action processing
      */
     suspend fun afterActionDispatch(state: S, action: A, nextState: S) {}
 
     /**
-     * Called before an event is emitted.
+     * Called before an event is emitted to collectors and observers.
      *
      * @param state The current state
      * @param event The event being emitted
@@ -46,7 +47,7 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun beforeEventEmit(state: S, event: E) {}
 
     /**
-     * Called after an event is emitted.
+     * Called after an event is emitted to collectors and observers.
      *
      * @param state The current state
      * @param event The emitted event
@@ -54,36 +55,36 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun afterEventEmit(state: S, event: E) {}
 
     /**
-     * Called before a new state begins.
+     * Called before the `enter {}` handler for a state runs.
      *
      * @param state The state that is beginning
      */
     suspend fun beforeStateEnter(state: S) {}
 
     /**
-     * Called after a new state has begun.
+     * Called after the `enter {}` handler finishes and its next state is determined.
      *
      * @param state The original state
-     * @param nextState The new state after beginning
+     * @param nextState The next state produced by the enter handler
      */
     suspend fun afterStateEnter(state: S, nextState: S) {}
 
     /**
-     * Called before a state ends.
+     * Called before the `exit {}` handler for a state runs.
      *
      * @param state The state that is ending
      */
     suspend fun beforeStateExit(state: S) {}
 
     /**
-     * Called after a state has ended.
+     * Called after the `exit {}` handler for a state finishes.
      *
      * @param state The state that ended
      */
     suspend fun afterStateExit(state: S) {}
 
     /**
-     * Called before a state changes.
+     * Called before a committed state snapshot is updated and persisted.
      *
      * @param state The current state
      * @param nextState The next state
@@ -91,7 +92,7 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun beforeStateChange(state: S, nextState: S) {}
 
     /**
-     * Called after a state has changed.
+     * Called after a new state snapshot is committed, persisted, and reported to observers.
      *
      * @param state The new state
      * @param prevState The previous state
@@ -99,7 +100,7 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun afterStateChange(state: S, prevState: S) {}
 
     /**
-     * Called before an error occurs.
+     * Called before a matching `error {}` handler runs for a non-fatal exception.
      *
      * @param state The current state
      * @param error The error that occurred
@@ -107,32 +108,36 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun beforeError(state: S, error: Throwable) {}
 
     /**
-     * Called after an error has been processed.
+     * Called after the matching `error {}` handler finishes and its next state is determined.
+     *
+     * This runs before any resulting state exit, state change, or state enter processing occurs.
      *
      * @param state The original state
-     * @param nextState The new state after error handling
+     * @param nextState The next state produced by error handling
      * @param error The error that occurred
      */
     suspend fun afterError(state: S, nextState: S, error: Throwable) {}
 }
 
 /**
- * Factory function to easily create a Middleware instance.
+ * Creates a [Middleware] from individual lifecycle callbacks.
  *
- * @param onStart Function called when the store is started with MiddlewareScope as receiver
- * @param beforeActionDispatch Function called before an action is dispatched
- * @param afterActionDispatch Function called after an action is dispatched
+ * These callbacks are suspending and are awaited by the Store just like a custom
+ * [Middleware] implementation.
+ *
+ * @param onStart Function called when the Store starts
+ * @param beforeActionDispatch Function called before an action handler starts
+ * @param afterActionDispatch Function called after an action handler determines its next state
  * @param beforeEventEmit Function called before an event is emitted
  * @param afterEventEmit Function called after an event is emitted
- * @param beforeStateEnter Function called before a new state begins
- * @param afterStateEnter Function called after a new state has begun
- * @param beforeStateExit Function called before a state ends
- * @param afterStateExit Function called after a state has ended
- * @param beforeStateChange Function called before a state changes
- * @param afterStateChange Function called after a state has changed
- * @param beforeError Function called before an error occurs
- * @param afterError Function called after an error has been processed
- * @return A new Middleware instance
+ * @param beforeStateEnter Function called before an enter handler runs
+ * @param afterStateEnter Function called after an enter handler determines its next state
+ * @param beforeStateExit Function called before an exit handler runs
+ * @param afterStateExit Function called after an exit handler finishes
+ * @param beforeStateChange Function called before a state snapshot is committed
+ * @param afterStateChange Function called after a state snapshot is committed
+ * @param beforeError Function called before an error handler runs
+ * @param afterError Function called after an error handler determines its next state
  */
 fun <S : State, A : Action, E : Event> Middleware(
     onStart: suspend MiddlewareScope<A>.(S) -> Unit = {},

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
@@ -4,12 +4,15 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 
 /**
- * Scope available to middleware components for processing actions.
- * Provides capabilities for action dispatching and coroutine launching.
+ * Scope exposed to [Middleware] hooks.
+ *
+ * Middleware can use this scope to dispatch additional actions or start Store-scoped background
+ * work.
  */
 interface MiddlewareScope<A : Action> {
     /**
-     * Dispatches an action to the store.
+     * Dispatches an action to the Store.
+     *
      * This enqueues the action and returns immediately.
      * It does not wait for action handling to complete.
      *
@@ -18,9 +21,9 @@ interface MiddlewareScope<A : Action> {
     fun dispatch(action: A)
 
     /**
-     * Launches a coroutine within the store's scope.
-     * The launched coroutine is tied to the Store lifecycle and is cancelled when the Store is closed.
-     * It is not cancelled automatically when the current state changes.
+     * Starts background work in the Store's root coroutine scope and returns immediately.
+     *
+     * The launched coroutine survives state changes and is cancelled only when the Store is closed.
      *
      * @param dispatcher Optional CoroutineDispatcher override for the coroutine.
      * When null, the coroutine inherits the Store's current execution context.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
@@ -1,19 +1,22 @@
 package io.yumemi.tart.core
 
 /**
- * Interface for persisting and restoring Store state.
- * Used to maintain state even when the application is restarted.
+ * Persists committed Store state snapshots and optionally restores the last saved snapshot.
+ *
+ * A restored snapshot replaces the declared initial state before Store startup processing begins.
  */
 interface StateSaver<S : State> {
     /**
-     * Saves the current state.
+     * Persists a committed state snapshot.
      *
      * @param state The state to save
      */
     fun save(state: S)
 
     /**
-     * Restores the saved state.
+     * Restores the snapshot to use before Store startup.
+     *
+     * Return `null` to fall back to the Store's declared initial state.
      *
      * @return The restored state, or null if there is no saved state
      */
@@ -21,9 +24,7 @@ interface StateSaver<S : State> {
 
     companion object {
         /**
-         * Creates a no-op implementation of StateSaver that doesn't persist or restore any state.
-         *
-         * @return A StateSaver instance that does not persist or restore any state
+         * Creates a no-op implementation that never restores and never persists state.
          */
         @Suppress("FunctionName")
         fun <S : State> Noop(): StateSaver<S> = object : StateSaver<S> {
@@ -36,11 +37,7 @@ interface StateSaver<S : State> {
 }
 
 /**
- * Factory function to easily create a StateSaver instance.
- *
- * @param save Callback function to save state
- * @param restore Callback function to restore state
- * @return A new StateSaver instance
+ * Creates a [StateSaver] from save and restore lambdas.
  */
 fun <S : State> StateSaver(save: (S) -> Unit, restore: () -> S?) = object : StateSaver<S> {
     override fun save(state: S) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -4,32 +4,33 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Core interface of Tart that provides application state management.
- * It has features such as state updates, event emission, action dispatching, etc.
+ * Core Tart interface for reading state, dispatching actions, and observing one-off events.
  *
  * Store startup is lazy.
- * Startup processing begins when the first action is [dispatch]ed, when [state] is collected,
- * or when [collectState] is called.
- * Collecting [event] or calling [collectEvent] alone does not start the Store.
+ * Startup processing begins when the first action is [dispatch]ed, when [state] starts being
+ * collected, or when [collectState] is called.
+ * Collecting [event], calling [collectEvent], or reading [currentState] alone does not start the
+ * Store.
  */
 interface Store<S : State, A : Action, E : Event> : AutoCloseable {
 
     /**
-     * StateFlow representing the current state. You can monitor state changes by subscribing to this.
+     * Hot stream of committed state snapshots.
      *
      * Collecting this flow starts the Store if it has not started yet.
      */
     val state: StateFlow<S>
 
     /**
-     * Flow of events. You can receive events by subscribing to this.
+     * Hot stream of one-off events emitted by the Store.
      *
      * Collecting this flow does not start the Store by itself.
+     * Past events are not replayed to new collectors.
      */
     val event: Flow<E>
 
     /**
-     * The value of the current state. Use this to get the current state without subscribing to the Flow.
+     * Current state snapshot without collecting [state].
      *
      * Reading this property does not start the Store.
      * If a [StateSaver] restores a saved state, this may return that restored snapshot
@@ -38,7 +39,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     val currentState: S
 
     /**
-     * Dispatches an action.
+     * Enqueues an action for processing.
      *
      * This enqueues the action and returns immediately.
      * It does not wait for action handling to complete.
@@ -49,7 +50,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     fun dispatch(action: A)
 
     /**
-     * Collects state changes using a callback.
+     * Collects committed state snapshots using a callback.
      *
      * This API is intended for platforms where [StateFlow] cannot be consumed directly.
      * Calling this method starts the Store if it has not started yet.
@@ -67,7 +68,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     fun collectState(state: (S) -> Unit)
 
     /**
-     * Collects events using a callback.
+     * Collects one-off events using a callback.
      *
      * This API is intended for platforms where [Flow] cannot be consumed directly.
      * Calling this method does not start the Store by itself.
@@ -81,13 +82,16 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      * before touching UI components from the callback.
      *
      * Collection continues until the Store is closed.
+     * Events emitted before collection starts are not replayed.
      *
      * @param event Callback called when an event is emitted
      */
     fun collectEvent(event: (E) -> Unit)
 
     /**
-     * Releases the Store's resources.
+     * Cancels the Store and releases its resources.
+     *
+     * Active state-scoped coroutines, middleware coroutines, and callback collectors are cancelled.
      */
     override fun close()
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -5,6 +5,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Builder used by the Store DSL to configure runtime behavior and register state-specific
+ * handlers.
+ *
+ * Most users interact with this type through the top-level `Store(...)` factory overloads.
+ */
 @Suppress("unused")
 @TartStoreDsl
 class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
@@ -17,7 +23,10 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**
-     * Sets the initial state of the store.
+     * Sets the declared initial state.
+     *
+     * This value is used when no [StateSaver] restores a saved snapshot.
+     * Later calls overwrite earlier ones.
      *
      * @param state The initial state to set
      */
@@ -26,7 +35,9 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Sets the coroutine context for store operations.
+     * Sets the root coroutine context used by Store processing.
+     *
+     * The default is [Dispatchers.Default].
      *
      * @param coroutineContext The coroutine context to use
      */
@@ -35,7 +46,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Sets the state saver implementation for persisting state.
+     * Sets the saver used to restore a snapshot before startup and persist committed state changes.
      *
      * @param stateSaver The state saver implementation to use
      */
@@ -44,7 +55,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Sets the exception handler for error handling.
+     * Sets the handler for non-fatal exceptions raised during Store processing.
      *
      * @param exceptionHandler The exception handler to use
      */
@@ -53,7 +64,8 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Sets how queued actions are handled when the store exits the current state.
+     * Sets how queued actions are treated when a committed state change leaves the current state
+     * variant.
      *
      * @param policy The pending action policy to use
      */
@@ -62,7 +74,10 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Sets how the store invokes middleware when multiple middleware instances are registered.
+     * Sets how the Store invokes middleware when multiple middleware instances are registered.
+     *
+     * Regardless of policy, the Store waits for all matching middleware hooks to complete before it
+     * continues processing.
      *
      * @param policy The middleware execution policy to use
      */
@@ -71,7 +86,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Adds one or more middleware instances to the store.
+     * Appends one or more middleware instances to the Store.
      *
      * @param first The first middleware instance to add
      * @param rest Additional middleware instances to add
@@ -220,12 +235,14 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Configures handlers for actions when the store is in a specific state type.
-     * This creates a DSL scope for defining type-specific action handlers.
+     * Configures handlers for a specific state subtype.
+     *
+     * Inside the block, you can register `enter {}`, `action {}`, `exit {}`, and `error {}`
+     * handlers narrowed to [S2].
      * Handler selection is first-match in registration order.
      * If both broad and specific handlers can match, place broader handlers later.
      *
-     * @param block The configuration block where you can define action handlers using the action() function
+     * @param block Configuration block for handlers that target [S2]
      */
     inline fun <reified S2 : S> state(noinline block: StateHandlerConfig<S, A, E, S2>.() -> Unit) {
         val config = StateHandlerConfig<S, A, E, S2>().apply(block)
@@ -299,20 +316,22 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
 }
 
 /**
- * Store DSL setup block.
+ * Main Store DSL block used to configure runtime behavior and register state handlers.
  */
 typealias Setup<S, A, E> = StoreBuilder<S, A, E>.() -> Unit
 
 /**
- * Store overrides block applied after the main Store setup.
- * This block is limited to non-state configuration such as coroutine context,
- * persistence, exception handling, pending action policy, and middleware.
+ * Store overrides block applied after the main [Setup] block.
+ *
+ * This block is limited to non-state configuration such as coroutine context, persistence,
+ * exception handling, pending action policy, and middleware.
  */
 typealias Overrides<S, A, E> = StoreOverridesBuilder<S, A, E>.() -> Unit
 
 /**
- * DSL for overriding Store configuration after the main setup has been applied.
- * This DSL intentionally does not expose state/action handler APIs.
+ * DSL for overriding non-state Store configuration after the main setup has been applied.
+ *
+ * This DSL intentionally does not expose state or action handler APIs.
  */
 @Suppress("unused")
 @TartStoreDsl
@@ -320,42 +339,43 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
     private val operations = mutableListOf<StoreBuilder<S, A, E>.() -> Unit>()
 
     /**
-     * Overrides the coroutine context for store operations.
+     * Overrides the root coroutine context used by Store processing.
      */
     fun coroutineContext(coroutineContext: CoroutineContext) {
         operations.add { coroutineContext(coroutineContext) }
     }
 
     /**
-     * Overrides the state saver used by the store.
+     * Overrides the saver used to restore and persist state snapshots.
      */
     fun stateSaver(stateSaver: StateSaver<S>) {
         operations.add { stateSaver(stateSaver) }
     }
 
     /**
-     * Overrides the exception handler used by the store.
+     * Overrides the handler used for non-fatal Store exceptions.
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         operations.add { exceptionHandler(exceptionHandler) }
     }
 
     /**
-     * Overrides how queued actions are handled when the store exits the current state.
+     * Overrides how queued actions are treated when a committed state change leaves the current
+     * state variant.
      */
     fun pendingActionPolicy(policy: PendingActionPolicy) {
         operations.add { pendingActionPolicy(policy) }
     }
 
     /**
-     * Overrides how the store invokes middleware when multiple middleware instances are registered.
+     * Overrides how the Store invokes middleware when multiple middleware instances are registered.
      */
     fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
         operations.add { middlewareExecutionPolicy(policy) }
     }
 
     /**
-     * Adds one or more middleware instances after the main Store setup.
+     * Appends middleware after the main setup block has run.
      */
     fun middleware(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
         val restValues = rest.copyOf()
@@ -363,8 +383,9 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
     }
 
     /**
-     * Replaces all middleware instances configured so far.
-     * This can be used to remove default middleware in tests or debug setups.
+     * Replaces every middleware configured so far.
+     *
+     * This is useful for removing default middleware in tests or debug setups.
      */
     fun replaceMiddlewares(first: Middleware<S, A, E>, vararg rest: Middleware<S, A, E>) {
         val restValues = rest.copyOf()
@@ -372,8 +393,9 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
     }
 
     /**
-     * Clears all middleware instances configured so far.
-     * This can be used to remove default middleware in tests or debug setups.
+     * Removes every middleware configured so far.
+     *
+     * This is useful for removing default middleware in tests or debug setups.
      */
     fun clearMiddlewares() {
         operations.add { clearMiddlewares() }
@@ -401,8 +423,10 @@ private fun <S : State, A : Action, E : Event> buildStore(
 }
 
 /**
- * Creates a Store instance with setup provided in the block and optional overrides.
- * The initial state must be set within the block using initialState().
+ * Creates a Store from a [Setup] block and optional [Overrides].
+ *
+ * The initial state must be set inside [setup] by calling [StoreBuilder.initialState].
+ * [overrides] runs after [setup], so it can replace non-state configuration declared there.
  *
  * @param overrides Overrides block for non-state Store configuration
  * @param setup Setup block to customize the store
@@ -417,10 +441,11 @@ fun <S : State, A : Action, E : Event> Store(
 }
 
 /**
- * Creates a Store instance with the specified initial state and optional overrides.
- * Overrides are applied after the main setup block.
+ * Creates a Store with a declared initial state and optional [Overrides].
  *
- * @param initialState The initial state of the store
+ * [overrides] runs after [setup], so it can replace non-state configuration declared there.
+ *
+ * @param initialState The initial state of the Store when no saved snapshot is restored
  * @param overrides Overrides block for non-state Store configuration
  * @param setup Setup block to customize the store
  * @return A configured Store instance
@@ -434,12 +459,13 @@ fun <S : State, A : Action, E : Event> Store(
 }
 
 /**
- * Creates a Store instance with the specified coroutine context and optional overrides.
- * The coroutine context parameter is applied before the main setup block.
- * The initial state must be set within the block using initialState().
- * Overrides are applied after the main setup block.
+ * Creates a Store with an explicit root coroutine context and optional [Overrides].
  *
- * @param coroutineContext The coroutine context to use for store operations
+ * The [coroutineContext] parameter is applied before [setup].
+ * The initial state must be set inside [setup] by calling [StoreBuilder.initialState].
+ * [overrides] runs after [setup], so it can replace non-state configuration declared there.
+ *
+ * @param coroutineContext The coroutine context to use for Store processing
  * @param overrides Overrides block for non-state Store configuration
  * @param setup Setup block to customize the store
  * @return A configured Store instance
@@ -454,12 +480,14 @@ fun <S : State, A : Action, E : Event> Store(
 }
 
 /**
- * Creates a Store instance with the specified initial state and coroutine context.
- * The initial state and coroutine context parameters are applied before the main setup block.
- * Overrides are applied after the main setup block.
+ * Creates a Store with a declared initial state, explicit root coroutine context, and optional
+ * [Overrides].
  *
- * @param initialState The initial state of the store
- * @param coroutineContext The coroutine context to use for store operations
+ * [initialState] and [coroutineContext] are applied before [setup].
+ * [overrides] runs after [setup], so it can replace non-state configuration declared there.
+ *
+ * @param initialState The initial state of the Store when no saved snapshot is restored
+ * @param coroutineContext The coroutine context to use for Store processing
  * @param overrides Overrides block for non-state Store configuration
  * @param setup Setup block to customize the store
  * @return A configured Store instance

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -3,14 +3,12 @@ package io.yumemi.tart.core
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
- * Base interface for all store scope types.
- * Provides a common type for different scopes in the state management flow.
+ * Marker supertype for DSL scopes exposed from Store handlers.
  */
 sealed interface StoreScope
 
 /**
- * Scope available when a state is being entered.
- * Used in enter handlers to manage state transitions and side effects.
+ * Scope available to an `enter {}` handler for the current state.
  */
 @TartStoreDsl
 interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
@@ -41,8 +39,9 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Clears actions that are already queued behind the currently executing store work.
-     * The action/transaction currently in progress keeps running.
+     * Cancels queued actions that have not started executing yet.
+     *
+     * The handler or transaction currently in progress keeps running.
      */
     fun clearPendingActions()
 
@@ -55,8 +54,9 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
     suspend fun event(event: E)
 
     /**
-     * Launches a coroutine within the context of this state.
-     * The coroutine will be automatically cancelled when the state is exited.
+     * Starts a state-scoped coroutine and returns immediately.
+     *
+     * The coroutine is cancelled automatically when this state exits.
      *
      * @param dispatcher Optional CoroutineDispatcher override for this coroutine.
      * When null, the coroutine inherits the Store's current execution context.
@@ -65,16 +65,12 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
     fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend EnterLaunchScope<S, E, S2>.() -> Unit)
 
     /**
-     * Scope available within a launched coroutine.
-     * Used for long-running operations or side effects within a state.
+     * Scope available within a state-scoped coroutine launched from `enter {}`.
      */
     @TartStoreDsl
     interface LaunchScope<S : State, E : Event, S2 : S> : StoreScope {
         /**
-         * Checks if the coroutine scope is still active.
-         * Use this to verify if the state is still active before performing operations.
-         *
-         * @return True if the scope is still active, false otherwise
+         * Whether the owning state runtime is still active.
          */
         val isActive: Boolean
 
@@ -86,8 +82,11 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
         suspend fun event(event: E)
 
         /**
-         * Executes a transactional operation within the launch scope.
-         * This allows state updates to be performed in an atomic, consistent manner.
+         * Runs a mutually exclusive transaction against the current Store state and suspends until it
+         * completes.
+         *
+         * If the state has already exited by the time the transaction would run, the transaction is
+         * skipped.
          *
          * @param dispatcher Optional CoroutineDispatcher override for this operation.
          * When null, the transaction inherits the Store's current execution context.
@@ -96,8 +95,7 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
         suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend EnterTransactionScope<S, E, S2>.() -> Unit)
 
         /**
-         * Scope available within a transaction operation.
-         * Used for atomic state updates with consistency guarantees.
+         * Scope available within a transaction started from an `enter {}` launch.
          */
         @TartStoreDsl
         interface TransactionScope<S : State, E : Event, S2 : S> : StoreScope {
@@ -128,8 +126,9 @@ interface EnterScope<S : State, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
-             * Clears actions that are already queued behind the currently executing store work.
-             * The action/transaction currently in progress keeps running.
+             * Cancels queued actions that have not started executing yet.
+             *
+             * The handler or transaction currently in progress keeps running.
              */
             fun clearPendingActions()
 
@@ -157,8 +156,7 @@ typealias EnterLaunchScope<S, E, S2> = EnterScope.LaunchScope<S, E, S2>
 typealias EnterTransactionScope<S, E, S2> = EnterScope.LaunchScope.TransactionScope<S, E, S2>
 
 /**
- * Scope available when a state is being exited.
- * Used in exit handlers to perform cleanup or side effects when leaving a state.
+ * Scope available to an `exit {}` handler for the current state.
  */
 @TartStoreDsl
 interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
@@ -168,8 +166,9 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
     val state: S2
 
     /**
-     * Clears actions that are already queued behind the currently executing store work.
-     * The action/transaction currently in progress keeps running.
+     * Cancels queued actions that have not started executing yet.
+     *
+     * The handler or transaction currently in progress keeps running.
      */
     fun clearPendingActions()
 
@@ -182,8 +181,7 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
 }
 
 /**
- * Scope available when an action is being processed.
- * Used in action handlers to update state based on an action.
+ * Scope available to an `action {}` handler for the current state and action.
  */
 @TartStoreDsl
 interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
@@ -194,7 +192,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     val state: S2
 
     /**
-     * The action being processed
+     * The action currently being processed.
      */
     val action: A
 
@@ -219,8 +217,9 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Clears actions that are already queued behind the currently executing store work.
-     * The action/transaction currently in progress keeps running.
+     * Cancels queued actions that have not started executing yet.
+     *
+     * The handler or transaction currently in progress keeps running.
      */
     fun clearPendingActions()
 
@@ -233,39 +232,35 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     suspend fun event(event: E)
 
     /**
-     * Cancels active coroutines launched from action handlers with the given lane
-     * in the current state's runtime when those launches are tracked by their launch control
-     * such as [LaunchControl.Replace] or [LaunchControl.DropNew].
+     * Cancels tracked launches in the current state's runtime for the given explicit lane.
      *
-     * If no matching launch exists, this is a no-op.
+     * Only launches started with [LaunchControl.Replace] or [LaunchControl.DropNew] and the same
+     * explicit [LaunchLane] are affected. If no matching launch exists, this is a no-op.
      *
      * @param lane The explicit launch lane identifying the cancellation group
      */
     fun cancelLaunch(lane: LaunchLane)
 
     /**
-     * Launches a coroutine within the context of the current state where this action is processed.
-     * The coroutine will be automatically cancelled when this state is exited.
+     * Starts a state-scoped coroutine from this action handler and returns immediately.
+     *
+     * The coroutine is cancelled automatically when this state exits.
      *
      * @param dispatcher Optional CoroutineDispatcher override for this coroutine.
      * When null, the coroutine inherits the Store's current execution context.
-     * @param control The launch control used for coordination. Tracked controls
-     * may use an explicit [LaunchLane] or the action-local default lane.
+     * @param control The launch control used for coordination. Tracked controls may use an
+     * explicit [LaunchLane] or the default lane for the current action type.
      * @param block The suspending block of code to execute
      */
     fun launch(dispatcher: CoroutineDispatcher? = null, control: LaunchControl = LaunchControl.Concurrent, block: suspend ActionLaunchScope<S, A, E, S2>.() -> Unit)
 
     /**
-     * Scope available within a launched coroutine from an action handler.
-     * Used for long-running operations or side effects within a state.
+     * Scope available within a state-scoped coroutine launched from `action {}`.
      */
     @TartStoreDsl
     interface LaunchScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         /**
-         * Checks if the coroutine scope is still active.
-         * Use this to verify if the state is still active before performing operations.
-         *
-         * @return True if the scope is still active, false otherwise
+         * Whether the owning state runtime is still active.
          */
         val isActive: Boolean
 
@@ -282,8 +277,11 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         suspend fun event(event: E)
 
         /**
-         * Executes a transactional operation within the launch scope.
-         * This allows state updates to be performed in an atomic, consistent manner.
+         * Runs a mutually exclusive transaction against the current Store state and suspends until it
+         * completes.
+         *
+         * If the state has already exited by the time the transaction would run, the transaction is
+         * skipped.
          *
          * @param dispatcher Optional CoroutineDispatcher override for this operation.
          * When null, the transaction inherits the Store's current execution context.
@@ -292,8 +290,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
         suspend fun transaction(dispatcher: CoroutineDispatcher? = null, block: suspend ActionTransactionScope<S, A, E, S2>.() -> Unit)
 
         /**
-         * Scope available within a transaction operation.
-         * Used for atomic state updates with consistency guarantees.
+         * Scope available within a transaction started from an `action {}` launch.
          */
         @TartStoreDsl
         interface TransactionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
@@ -304,7 +301,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             val state: S2
 
             /**
-             * The action being processed when the launch was started.
+             * The action that started the launch owning this transaction.
              */
             val action: A
 
@@ -329,8 +326,9 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
-             * Clears actions that are already queued behind the currently executing store work.
-             * The action/transaction currently in progress keeps running.
+             * Cancels queued actions that have not started executing yet.
+             *
+             * The handler or transaction currently in progress keeps running.
              */
             fun clearPendingActions()
 
@@ -358,8 +356,7 @@ typealias ActionLaunchScope<S, A, E, S2> = ActionScope.LaunchScope<S, A, E, S2>
 typealias ActionTransactionScope<S, A, E, S2> = ActionScope.LaunchScope.TransactionScope<S, A, E, S2>
 
 /**
- * Scope available when an error occurs in a state handler.
- * Used in error handlers to recover from errors or update state accordingly.
+ * Scope available to an `error {}` handler after a non-fatal exception is caught.
  */
 @TartStoreDsl
 interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
@@ -370,7 +367,7 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     val state: S2
 
     /**
-     * The error that occurred
+     * The error currently being handled.
      */
     val error: T
 
@@ -395,8 +392,9 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Clears actions that are already queued behind the currently executing store work.
-     * The action/transaction currently in progress keeps running.
+     * Cancels queued actions that have not started executing yet.
+     *
+     * The handler or transaction currently in progress keeps running.
      */
     fun clearPendingActions()
 

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
@@ -3,19 +3,13 @@ package io.yumemi.tart.logging
 import co.touchlab.kermit.Logger.Companion as Kermit
 
 /**
- * Default implementation of the Logger interface using Kermit.
- * Used as the default logger for the Tart framework.
+ * Default [Logger] implementation backed by Kermit.
  */
 object DefaultLogger : Logger {
     private var isDisabled = false
 
     /**
-     * Outputs a log with the specified severity.
-     *
-     * @param severity The severity of the log
-     * @param tag The tag for the log
-     * @param throwable Associated exception (if any)
-     * @param message Provider for the log message
+     * Emits a log entry unless this logger has been disabled.
      */
     override fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: () -> String) {
         if (isDisabled) return
@@ -30,7 +24,7 @@ object DefaultLogger : Logger {
     }
 
     /**
-     * Disables the logger. After disabling, no logs will be output.
+     * Disables this logger for the rest of the process.
      */
     @Suppress("unused")
     fun disable() {

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/Logger.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/Logger.kt
@@ -1,12 +1,11 @@
 package io.yumemi.tart.logging
 
 /**
- * Interface that provides logging functionality.
- * Used for logging internal Tart operations and diagnostic information.
+ * Logging abstraction used by Tart middleware and diagnostics.
  */
 fun interface Logger {
     /**
-     * Outputs a log with the specified severity.
+     * Emits a log entry at the given severity.
      *
      * @param severity The severity of the log
      * @param tag The tag for the log
@@ -21,8 +20,7 @@ fun interface Logger {
     )
 
     /**
-     * Enumeration representing log severity levels.
-     * Supports common logging levels.
+     * Supported log severity levels.
      */
     enum class Severity {
         /** Very detailed debug information */

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
@@ -8,7 +8,9 @@ import io.yumemi.tart.core.State
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
- * Middleware that logs Store operations.
+ * Base middleware for logging Store operations without blocking Store processing.
+ *
+ * Log writes are dispatched from [log] by launching work in [MiddlewareScope].
  *
  * @param logger Logger to use
  * @param dispatcher Optional CoroutineDispatcher override for log processing.
@@ -32,15 +34,13 @@ abstract class LoggingMiddleware<S : State, A : Action, E : Event>(
 }
 
 /**
- * Creates a simple logging middleware that logs Store operations.
- * This middleware logs all action dispatches, state changes, event emissions, and errors
- * with the specified severity level.
+ * Creates a middleware that logs actions, events, committed state changes, and errors.
  *
  * @param tag The tag to use for logging
  * @param severity The severity level for log messages
  * @param logger The logger implementation to use
  * @param dispatcher Optional CoroutineDispatcher override for logging operations
- * @return A middleware that performs logging for all store operations
+ * @return Middleware that logs common Store operations
  */
 fun <S : State, A : Action, E : Event> simpleLogging(
     tag: String = "Tart",

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/Message.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/Message.kt
@@ -5,8 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 /**
- * Marker interface representing notifications or messages within the application.
- * Used to define messages for communication between different modules via Store.
+ * Marker interface for process-wide messages sent through Tart's shared message bus.
  */
 interface Message
 
@@ -20,11 +19,10 @@ internal object MessageHub {
 }
 
 /**
- * Extension function for sending messages to the MessageHub.
- * This allows any StoreScope to easily send messages to other components.
+ * Sends a [Message] to Tart's process-wide shared message bus.
  *
- * Messages are sent to a process-wide shared bus.
- * All started Stores using `receiveMessages(...)` subscribe to the same bus.
+ * Any DSL scope that implements [StoreScope] can call this, including enter, action, exit, error,
+ * launch, and transaction scopes.
  * Messages are not replayed, so receivers that are not actively collecting when a message is sent
  * will not receive that past message.
  *

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
@@ -19,15 +19,16 @@ private abstract class MiddlewareImpl<S : State, A : Action, E : Event> : Middle
 }
 
 /**
- * Creates a middleware that receives messages from the MessageHub.
- * This middleware automatically subscribes to the message flow when the store starts
- * and processes each message with the provided block.
+ * Creates middleware that subscribes to Tart's shared message bus when the Store starts.
  *
- * The underlying MessageHub is process-wide and shared across all Stores using this middleware.
- * Messages are delivered only to active subscribers and are not replayed to Stores that start later.
+ * The subscription stays active until the Store closes and invokes [block] for each received
+ * [Message].
+ * The underlying bus is process-wide and shared across all Stores using this middleware.
+ * Messages are delivered only to active subscribers and are not replayed to Stores that start
+ * later.
  *
- * @param block The function to process received messages with MiddlewareScope as receiver
- * @return A middleware that processes messages
+ * @param block Function to process received messages with [MiddlewareScope] as receiver
+ * @return Middleware that processes shared messages
  */
 fun <S : State, A : Action, E : Event> receiveMessages(block: suspend MiddlewareScope<A>.(Message) -> Unit): Middleware<S, A, E> {
     return object : MiddlewareImpl<S, A, E>() {

--- a/tart-test/src/commonMain/kotlin/io/yumemi/tart/test/StoreExtensions.kt
+++ b/tart-test/src/commonMain/kotlin/io/yumemi/tart/test/StoreExtensions.kt
@@ -9,12 +9,13 @@ import io.yumemi.tart.core.StoreInternalApi
 import io.yumemi.tart.core.StoreObserver
 
 /**
- * Dispatches an action and suspends until the dispatch work completes.
+ * Dispatches an action and suspends until the Store finishes the dispatch work itself.
  *
- * This waits for the action handling performed as part of the dispatch itself.
- * It does not wait for additional work launched from action/enter handlers.
+ * This waits for startup, the matching action handler, and any resulting synchronous state
+ * transition work triggered by that dispatch.
+ * It does not wait for additional work launched from `enter {}` or `action {}` handlers.
  *
- * This extension is available for Store instances created by Tart DSL.
+ * This extension is available for Store instances created by the Tart DSL.
  *
  * @param action The action to dispatch
  * @throws IllegalStateException if the Store is not backed by Tart's internal implementation
@@ -25,10 +26,13 @@ suspend fun <S : State, A : Action, E : Event> Store<S, A, E>.dispatchAndWait(ac
 }
 
 /**
- * Attaches an observer before the store is started.
- * This does not start the store.
+ * Attaches an observer before the Store starts.
  *
- * This extension is available for Store instances created by Tart DSL.
+ * This does not start the Store.
+ * If [notifyCurrentState] is true, the observer receives the current snapshot immediately, which
+ * may be a [io.yumemi.tart.core.StateSaver]-restored value.
+ *
+ * This extension is available for Store instances created by the Tart DSL.
  *
  * @param observer The observer to attach
  * @param notifyCurrentState Whether to notify the observer with the current state immediately

--- a/tart-test/src/commonMain/kotlin/io/yumemi/tart/test/StoreRecorder.kt
+++ b/tart-test/src/commonMain/kotlin/io/yumemi/tart/test/StoreRecorder.kt
@@ -9,6 +9,8 @@ import io.yumemi.tart.core.StoreObserver
 
 /**
  * Default in-memory [StoreObserver] implementation for tests.
+ *
+ * It records every observed state snapshot and event in insertion order.
  */
 @ExperimentalTartApi
 class StoreRecorder<S : State, E : Event> : StoreObserver<S, E> {
@@ -43,11 +45,11 @@ class StoreRecorder<S : State, E : Event> : StoreObserver<S, E> {
 }
 
 /**
- * Creates and attaches the default [StoreRecorder] for this Store.
+ * Creates and attaches a [StoreRecorder] for this Store.
  *
  * Prefer this in tests unless you need a custom [StoreObserver] implementation.
  *
- * @param notifyCurrentState Whether to notify the recorder with the current state immediately
+ * @param notifyCurrentState Whether to record the current state snapshot immediately
  * @return The attached [StoreRecorder]
  */
 @ExperimentalTartApi


### PR DESCRIPTION
## Summary
- align public API KDoc wording across core, compose, message, logging, and test modules
- clarify lifecycle timing for startup, event replay, launches, transactions, and pending action handling
- tighten override, middleware, and observer documentation to better match runtime behavior

## Why
- reduce wording drift across modules
- make behavior around lifecycle timing and asynchronous work easier to understand from the API docs alone

## Impact
- documentation-only changes
- no runtime behavior changes

## Verification
- ./gradlew :tart-core:compileKotlinMetadata :tart-compose:compileKotlinMetadata :tart-message:compileKotlinMetadata :tart-logging:compileKotlinMetadata :tart-test:compileKotlinMetadata