### PR TITLE
Refine LaunchControl API naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ val store = Store(MyState.Active()) {
         action<MyAction.QueryChanged> {
             nextState(state.copy(query = action.query, isLoading = true))
 
-            launch(control = LaunchControl.Replace(searchLane)) {
+            launch(control = LaunchControl.CancelPrevious(searchLane)) {
                 delay(300)
                 val result = repository.search(action.query)
                 transaction {
@@ -517,7 +517,7 @@ val store = Store(MyState.Active()) {
         }
 
         action<MyAction.Submit> {
-            launch(control = LaunchControl.DropNew()) {
+            launch(control = LaunchControl.DropIfRunning()) {
                 submit()
             }
         }
@@ -525,11 +525,11 @@ val store = Store(MyState.Active()) {
 }
 ```
 
-`LaunchControl.Replace(lane)` cancels the previous tracked launch in the same lane before starting the next one.
-`LaunchControl.DropNew(lane)` ignores new launches while tracked work in the same lane is still active.
-When the lane is omitted, `LaunchControl.Replace()` and `LaunchControl.DropNew()` use the same internal default lane for that `action {}` block.
+`LaunchControl.CancelPrevious(lane)` cancels the previous tracked launch in the same lane before starting the next one.
+`LaunchControl.DropIfRunning(lane)` ignores a new launch while tracked work in the same lane is still active.
+When the lane is omitted, `LaunchControl.CancelPrevious()` and `LaunchControl.DropIfRunning()` use the same internal default lane for that `action {}` block.
 `LaunchControl.Concurrent` keeps the default behavior and runs launches independently.
-`cancelLaunch(lane)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.Replace(...)` and `LaunchControl.DropNew(...)`. Use an explicit `LaunchLane()` when you need to share a lane across multiple launches or cancel it later. It does not cancel `LaunchControl.Concurrent` launches or `enter { launch { ... } }`.
+`cancelLaunch(lane)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.CancelPrevious(...)` and `LaunchControl.DropIfRunning(...)`. Use an explicit `LaunchLane()` when you need to share a lane across multiple launches or cancel it later. It does not cancel `LaunchControl.Concurrent` launches or `enter { launch { ... } }`.
 
 ### Specifying coroutineContext
 

--- a/doc/internal/adr/2026-04-28-debounce-throttle.md
+++ b/doc/internal/adr/2026-04-28-debounce-throttle.md
@@ -6,7 +6,7 @@
 
 `dispatch()` に対して `debounce` や `throttle` のような時間窓ベースの制御を、Store の built-in として用意するかを検討した。
 
-`LaunchControl.Replace` や `LaunchControl.DropNew` も、active job の有無や起動順で振る舞いが変わるため、一見すると `debounce` / `throttle` と近い論点に見える。
+`LaunchControl.CancelPrevious` や `LaunchControl.DropIfRunning` も、active job の有無や起動順で振る舞いが変わるため、一見すると `debounce` / `throttle` と近い論点に見える。
 ただし、これらが扱うのは key 付き lane に紐づいた launched job をどう調停するかであり、意味は job coordination の中に閉じている。
 
 一方 `debounce` / `throttle` は、時間窓の中で複数回の入力をどうまとめるか、どれを落とすか、いつ実行するかを決める control であり、job 単位の制御より「入力の採否や実行タイミングを決める仕組み」としての意味合いが強い。
@@ -26,7 +26,7 @@
 ## 補足
 
 - 見送る理由の中心は、単に時間要素を含む制御だからではなく、`debounce` / `throttle` が tracked job の coordination というより、時間窓内で入力の採否や実行タイミングを決める仕組みとして振る舞うためである。
-- `LaunchControl.Replace` / `DropNew` は、「この lane の launched job を置き換える」「この lane に active job がある間は新しい launched job を始めない」という意味で、job に紐づく control としてまだ読みやすい。
+- `LaunchControl.CancelPrevious` / `DropIfRunning` は、「この lane の前回 launched job を止めて次を始める」「この lane に active job がある間は新しい launched job を始めない」という意味で、job に紐づく control としてまだ読みやすい。
 - `debounce` / `throttle` により dispatch が失われても、それが仕様なのか不具合なのかを利用者が判断しづらくなりやすい。
 - これらの制御が必要になる場面は、検索入力、連打防止、スクロール連動など、UI 起点のイベント整形であることが多い。そのため現段階では、Store の責務として吸収するより、UI 側でイベントを整えてから `dispatch()` する方が自然である。
 - 将来もし同種の要求が増えても、まずは利用場面ごとの意図と失われてよい dispatch の条件を整理すべきであり、汎用の built-in を先に増やす判断は採らない。

--- a/doc/internal/adr/2026-05-01-launch-control-case-naming.md
+++ b/doc/internal/adr/2026-05-01-launch-control-case-naming.md
@@ -1,0 +1,29 @@
+# `LaunchControl` API のデザイン
+
+- 更新日: 2026-05-01
+
+## 背景
+
+`LaunchControl` は `action { launch { ... } }` に対して、tracked lane 上で launched job をどう調停するかを表す API である。
+
+この control は、dispatch 自体を捨てるわけではないが、dispatch をきっかけに始まる launched work を開始しない、あるいは前回の launched work を取り消すことがある。
+そのため便利な一方で、意図せず使うと「一見すると action が無視されたように見える」振る舞いにつながりうる。
+
+利用者が混乱なく利用できる API であることが求められる。
+
+## 決定
+
+`LaunchControl` は、次の case を持つ API として公開する。
+
+- `LaunchControl.Concurrent` (デフォルト。通常は省略される。)
+- `LaunchControl.CancelPrevious`
+- `LaunchControl.DropIfRunning`
+
+canonical な書き方は、`launch(control = LaunchControl.CancelPrevious(...)) { ... }` および `launch(control = LaunchControl.DropIfRunning(...)) { ... }` とする。
+
+## 補足
+
+- `CancelPrevious` は「前回の tracked launch を止めて次を始める」、`DropIfRunning` は「tracked launch が動作中なら新しい launch を始めない」という挙動が call site から直接読める。
+- `launchCancelPrevious()` / `launchDropIfRunning()` のような API 群へ置き換えも検討したが、利用者が覚えるべき `launchXxx` 構文が増えるので採用しない。
+- `launchCancelPrevious()` / `launchDropIfRunning()` を置き換えでなく alias として追加することも検討したが、同じ制御に複数の入口を用意すると、README、レビュー、会話、検索のどれでも表記が混ざり、認知負荷が上がる。そのため public surface は 1 つの書き方に絞る。
+- `launch(control = LaunchControl.CancelPrevious(searchLane)) { ... }` のような少し長めの表記でも、コード中で視認しやすい方が、コードレビュー中に見落としづらい。

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/LaunchControl.kt
@@ -12,9 +12,9 @@ class LaunchLane
  * Controls how `action {}` launches coordinate with other tracked launches in the same lane.
  *
  * [Concurrent] launches are not tracked by lane.
- * [Replace] and [DropNew] create tracked lanes. When [LaunchLane] is omitted, the launch uses a
- * default lane derived from the current action type, so matching launches coordinate across
- * dispatches of that action type.
+ * [CancelPrevious] and [DropIfRunning] create tracked lanes. When [LaunchLane] is omitted, the
+ * launch uses a default lane derived from the current action type, so matching launches
+ * coordinate across dispatches of that action type.
  */
 sealed interface LaunchControl {
 
@@ -26,10 +26,10 @@ sealed interface LaunchControl {
     /**
      * Cancel the previous tracked launch in the same lane before starting a new one.
      */
-    data class Replace(val lane: LaunchLane? = null) : LaunchControl
+    data class CancelPrevious(val lane: LaunchLane? = null) : LaunchControl
 
     /**
      * Ignore a new launch while tracked work in the same lane is still active.
      */
-    data class DropNew(val lane: LaunchLane? = null) : LaunchControl
+    data class DropIfRunning(val lane: LaunchLane? = null) : LaunchControl
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -420,7 +420,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 )
             }
 
-            is LaunchControl.Replace -> {
+            is LaunchControl.CancelPrevious -> {
                 val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
                 cancelTrackedActionLaunch(stateRuntime, trackedKey)
                 stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
@@ -432,7 +432,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 )
             }
 
-            is LaunchControl.DropNew -> {
+            is LaunchControl.DropIfRunning -> {
                 val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
                 if (stateRuntime.actionLaunchJobs[trackedKey]?.isActive == true) return
                 stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
@@ -472,8 +472,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private fun resolveTrackedActionLaunchKey(action: A, control: LaunchControl): Any {
         return when (control) {
             LaunchControl.Concurrent -> error("Concurrent launches do not have a tracked lane")
-            is LaunchControl.Replace -> control.lane ?: action::class
-            is LaunchControl.DropNew -> control.lane ?: action::class
+            is LaunchControl.CancelPrevious -> control.lane ?: action::class
+            is LaunchControl.DropIfRunning -> control.lane ?: action::class
         }
     }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -234,8 +234,9 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     /**
      * Cancels tracked launches in the current state's runtime for the given explicit lane.
      *
-     * Only launches started with [LaunchControl.Replace] or [LaunchControl.DropNew] and the same
-     * explicit [LaunchLane] are affected. If no matching launch exists, this is a no-op.
+     * Only launches started with [LaunchControl.CancelPrevious] or
+     * [LaunchControl.DropIfRunning] and the same explicit [LaunchLane] are affected.
+     * If no matching launch exists, this is a no-op.
      *
      * @param lane The explicit launch lane identifying the cancellation group
      */

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreCancelLaunchTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreCancelLaunchTest.kt
@@ -20,9 +20,9 @@ class StoreCancelLaunchTest {
     }
 
     sealed interface AppAction : Action {
-        data class StartDropNewShared(val marker: Int) : AppAction
-        data class StartDropNewOther(val marker: Int) : AppAction
-        data class StartReplaceShared(val marker: Int) : AppAction
+        data class StartDropIfRunningShared(val marker: Int) : AppAction
+        data class StartDropIfRunningOther(val marker: Int) : AppAction
+        data class StartCancelPreviousShared(val marker: Int) : AppAction
         data class StartConcurrentShared(val marker: Int) : AppAction
         data object StartEnterLaunch : AppAction
         data object CancelShared : AppAction
@@ -49,10 +49,10 @@ class StoreCancelLaunchTest {
                     }
                 }
 
-                action<AppAction.StartDropNewShared> {
+                action<AppAction.StartDropIfRunningShared> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew(sharedLane),
+                        control = LaunchControl.DropIfRunning(sharedLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -63,10 +63,10 @@ class StoreCancelLaunchTest {
                     }
                 }
 
-                action<AppAction.StartDropNewOther> {
+                action<AppAction.StartDropIfRunningOther> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew(otherLane),
+                        control = LaunchControl.DropIfRunning(otherLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -77,10 +77,10 @@ class StoreCancelLaunchTest {
                     }
                 }
 
-                action<AppAction.StartReplaceShared> {
+                action<AppAction.StartCancelPreviousShared> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(sharedLane),
+                        control = LaunchControl.CancelPrevious(sharedLane),
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -121,7 +121,7 @@ class StoreCancelLaunchTest {
     }
 
     @Test
-    fun cancelLaunch_cancelsDropNewLaunchWithMatchingLane() = runTest {
+    fun cancelLaunch_cancelsDropIfRunningLaunchWithMatchingLane() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val cancelled = mutableListOf<Int>()
         val store = createStore(
@@ -129,7 +129,7 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartDropNewShared(marker = 1))
+        store.dispatch(AppAction.StartDropIfRunningShared(marker = 1))
         runCurrent()
 
         store.dispatch(AppAction.CancelShared)
@@ -139,7 +139,7 @@ class StoreCancelLaunchTest {
     }
 
     @Test
-    fun cancelLaunch_cancelsReplaceLaunchWithMatchingLane() = runTest {
+    fun cancelLaunch_cancelsCancelPreviousLaunchWithMatchingLane() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val started = mutableListOf<Int>()
         val cancelled = mutableListOf<Int>()
@@ -149,7 +149,7 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartReplaceShared(marker = 9))
+        store.dispatch(AppAction.StartCancelPreviousShared(marker = 9))
         runCurrent()
 
         assertEquals(listOf(-1, 9), started)
@@ -169,8 +169,8 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartDropNewShared(marker = 1))
-        store.dispatch(AppAction.StartDropNewOther(marker = 100))
+        store.dispatch(AppAction.StartDropIfRunningShared(marker = 1))
+        store.dispatch(AppAction.StartDropIfRunningOther(marker = 100))
         runCurrent()
 
         store.dispatch(AppAction.CancelShared)
@@ -205,10 +205,10 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartDropNewShared(marker = 1))
+        store.dispatch(AppAction.StartDropIfRunningShared(marker = 1))
         runCurrent()
 
-        store.dispatch(AppAction.StartReplaceShared(marker = 9))
+        store.dispatch(AppAction.StartCancelPreviousShared(marker = 9))
         runCurrent()
 
         assertEquals(listOf(-1, 1, 9), started)
@@ -250,7 +250,7 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartDropNewShared(marker = 1))
+        store.dispatch(AppAction.StartDropIfRunningShared(marker = 1))
         runCurrent()
 
         store.dispose()

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchControlTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreLaunchControlTest.kt
@@ -18,19 +18,19 @@ class StoreLaunchControlTest {
     }
 
     sealed interface AppAction : Action {
-        data class ReplaceDefault(val marker: Int) : AppAction
+        data class CancelPreviousDefault(val marker: Int) : AppAction
         data object KeyedLaunches : AppAction
         data object SharedDefaultLane : AppAction
         data object SharedDefaultLaneAcrossControls : AppAction
-        data class DropNewAdd(val delta: Int) : AppAction
+        data class DropIfRunningAdd(val delta: Int) : AppAction
         data class LatestAdd(val delta: Int) : AppAction
         data object MoveToCompleted : AppAction
     }
 
     private fun createStore(
         testDispatcher: TestDispatcher,
-        onReplaceStart: ((Int) -> Unit)? = null,
-        onReplaceCancel: ((Int) -> Unit)? = null,
+        onCancelPreviousStart: ((Int) -> Unit)? = null,
+        onCancelPreviousCancel: ((Int) -> Unit)? = null,
     ): Store<AppState, AppAction, Nothing> {
         val primaryLane = LaunchLane()
         val secondaryLane = LaunchLane()
@@ -38,16 +38,16 @@ class StoreLaunchControlTest {
             coroutineContext(testDispatcher)
 
             state<AppState.Active> {
-                action<AppAction.ReplaceDefault> {
+                action<AppAction.CancelPreviousDefault> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(),
+                        control = LaunchControl.CancelPrevious(),
                     ) {
-                        onReplaceStart?.invoke(action.marker)
+                        onCancelPreviousStart?.invoke(action.marker)
                         try {
                             delay(Long.MAX_VALUE)
                         } finally {
-                            onReplaceCancel?.invoke(action.marker)
+                            onCancelPreviousCancel?.invoke(action.marker)
                         }
                     }
                 }
@@ -55,7 +55,7 @@ class StoreLaunchControlTest {
                 action<AppAction.KeyedLaunches> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(primaryLane),
+                        control = LaunchControl.CancelPrevious(primaryLane),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 1))
@@ -63,7 +63,7 @@ class StoreLaunchControlTest {
                     }
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(secondaryLane),
+                        control = LaunchControl.CancelPrevious(secondaryLane),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 10))
@@ -74,7 +74,7 @@ class StoreLaunchControlTest {
                 action<AppAction.SharedDefaultLane> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(),
+                        control = LaunchControl.CancelPrevious(),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 1))
@@ -82,7 +82,7 @@ class StoreLaunchControlTest {
                     }
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(),
+                        control = LaunchControl.CancelPrevious(),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 10))
@@ -93,7 +93,7 @@ class StoreLaunchControlTest {
                 action<AppAction.SharedDefaultLaneAcrossControls> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(),
+                        control = LaunchControl.CancelPrevious(),
                     ) {
                         delay(100)
                         transaction(testDispatcher) {
@@ -102,7 +102,7 @@ class StoreLaunchControlTest {
                     }
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew(),
+                        control = LaunchControl.DropIfRunning(),
                     ) {
                         transaction(testDispatcher) {
                             nextState(state.copy(value = state.value + 10))
@@ -110,10 +110,10 @@ class StoreLaunchControlTest {
                     }
                 }
 
-                action<AppAction.DropNewAdd> {
+                action<AppAction.DropIfRunningAdd> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.DropNew(),
+                        control = LaunchControl.DropIfRunning(),
                     ) {
                         delay(100)
                         transaction(testDispatcher) {
@@ -125,7 +125,7 @@ class StoreLaunchControlTest {
                 action<AppAction.LatestAdd> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Replace(),
+                        control = LaunchControl.CancelPrevious(),
                     ) {
                         delay(100)
                         transaction(testDispatcher) {
@@ -142,23 +142,23 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_replaceCancelsMatchingLaneAcrossDispatches() = runTest {
+    fun launchControl_cancelPreviousCancelsMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val started = mutableListOf<Int>()
         val cancelled = mutableListOf<Int>()
         val store = createStore(
             testDispatcher = testDispatcher,
-            onReplaceStart = { started += it },
-            onReplaceCancel = { cancelled += it },
+            onCancelPreviousStart = { started += it },
+            onCancelPreviousCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.ReplaceDefault(marker = 1))
+        store.dispatch(AppAction.CancelPreviousDefault(marker = 1))
         runCurrent()
 
         assertEquals(listOf(1), started)
         assertEquals(emptyList(), cancelled)
 
-        store.dispatch(AppAction.ReplaceDefault(marker = 2))
+        store.dispatch(AppAction.CancelPreviousDefault(marker = 2))
         runCurrent()
 
         assertEquals(listOf(1, 2), started)
@@ -166,15 +166,15 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_replaceLaunchIsCancelledOnStateChange() = runTest {
+    fun launchControl_cancelPreviousLaunchIsCancelledOnStateChange() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val cancelled = mutableListOf<Int>()
         val store = createStore(
             testDispatcher = testDispatcher,
-            onReplaceCancel = { cancelled += it },
+            onCancelPreviousCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.ReplaceDefault(marker = 1))
+        store.dispatch(AppAction.CancelPreviousDefault(marker = 1))
         runCurrent()
 
         store.dispatch(AppAction.MoveToCompleted)
@@ -223,12 +223,12 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_dropNewUsesMatchingLaneAcrossDispatches() = runTest {
+    fun launchControl_dropIfRunningUsesMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 
-        store.dispatch(AppAction.DropNewAdd(delta = 1))
-        store.dispatch(AppAction.DropNewAdd(delta = 10))
+        store.dispatch(AppAction.DropIfRunningAdd(delta = 1))
+        store.dispatch(AppAction.DropIfRunningAdd(delta = 10))
         runCurrent()
 
         assertEquals(AppState.Active(value = 0), store.currentState)
@@ -238,7 +238,7 @@ class StoreLaunchControlTest {
 
         assertEquals(AppState.Active(value = 1), store.currentState)
 
-        store.dispatch(AppAction.DropNewAdd(delta = 10))
+        store.dispatch(AppAction.DropIfRunningAdd(delta = 10))
         runCurrent()
 
         advanceTimeBy(100)
@@ -248,7 +248,7 @@ class StoreLaunchControlTest {
     }
 
     @Test
-    fun launchControl_replaceUsesMatchingLaneAcrossDispatches() = runTest {
+    fun launchControl_cancelPreviousUsesMatchingLaneAcrossDispatches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val store = createStore(testDispatcher)
 


### PR DESCRIPTION
## Summary
- Rename LaunchControl cases to CancelPrevious and DropIfRunning across the core API, tests, and README.
- Add an ADR that documents why the explicit launch(control = LaunchControl...) form remains the canonical surface.

## Why
- Make the launch control behaviors more explicit at call sites.
- Keep one clear API entry point instead of introducing multiple launchXxx variants.

## Verification
- ./gradlew :tart-core:jvmTest