### PR TITLE
Add store plugin extension point

### DIFF
--- a/doc/internal/notes/2026-05-02-plugin-design.md
+++ b/doc/internal/notes/2026-05-02-plugin-design.md
@@ -1,0 +1,165 @@
+# Plugin 設計メモ
+
+- 更新日: 2026-05-02
+
+## 背景
+
+Tart にはすでに `Middleware` があるが、hook 数が多く、`before/after` の internal lifecycle がそのまま public API に出ている。
+
+一方で、logging、analytics、message bridge、autosave、sync のような用途では、必ずしも `Middleware` と同じ粒度や性質の hook は要らない。
+必要なのは interception より、Store の開始、action、state 更新、event、recoverable error を外側から観測し、必要なら補助的な非同期処理や追加 dispatch を行える拡張点である。
+
+そのため、`Middleware` とは別に、より小さい surface を持つ `Plugin` を追加する方向で整理したい。
+
+今回の論点は次のとおり。
+
+- `Plugin` は何のための拡張点か
+- どの hook を公開するか
+- `close` hook を持つか
+- `Middleware` のような execution policy を持つか
+
+## 現在の考え
+
+### `Plugin` の役割
+
+`Plugin` は Store の本体 pipeline を横取りするためのものではなく、**観測と外部連携のための拡張点**として扱う。
+
+- logging や analytics の記録
+- message bus / websocket / push などの購読開始
+- state 更新後の保存や同期
+- recoverable error の報告
+- 補助的な action dispatch
+
+逆に、現在処理中の action を差し替える、握りつぶす、`nextState` を横から書き換える、といった interception は `Plugin` の責務にしない。
+
+### surface
+
+現時点の `Plugin` surface は次を基本にする。
+
+```kt
+interface Plugin<S : State, A : Action, E : Event> {
+    suspend fun onStart(scope: PluginScope<S, A>, state: S) {}
+    suspend fun onAction(scope: PluginScope<S, A>, state: S, action: A) {}
+    suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {}
+    suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {}
+    suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {}
+}
+
+interface PluginScope<S : State, A : Action> {
+    val currentState: S
+    fun dispatch(action: A)
+    fun launch(
+        dispatcher: CoroutineDispatcher? = null,
+        block: suspend CoroutineScope.() -> Unit,
+    )
+}
+```
+
+hook の位相は次のように揃える。
+
+- `onStart`
+  - Store start 時
+  - 初回 `enter {}` の前
+- `onAction`
+  - action handler 開始前
+- `onStateChanged`
+  - state commit と save の後
+- `onEvent`
+  - event emit 前
+- `onError`
+  - recoverable error の handler 実行前
+
+`onAction` / `onEvent` / `onError` は開始地点に寄せ、`onStateChanged` だけは更新後の hook とする。
+state type change を見たい場合は、`onStateChanged` の中で `prevState::class != state::class` を見れば足りるので、専用 hook は持たない。
+
+名前を `onState` ではなく `onStateChanged` にしているのは、`StoreObserver.onState(state)` と契約が異なるためである。
+observer の `onState` は「Store が state snapshot を observer に見せる」通知であり、attach 時の設定によっては start 前の current state を即時に受け取ることもある。
+一方 plugin 側で欲しいのは「新しい state が commit され、保存まで済んだ」という更新通知であり、`prevState` も必要になる。
+同じ `onState` という名前にすると、snapshot 観測と committed update 観測の違いが見えにくくなるため、plugin 側は `onStateChanged` として分ける。
+
+`onError` の型は `Throwable` ではなく `Exception` とする。
+Tart の recoverable error path は `Exception` に限定されており、`CancellationException` やそれ以外の `Throwable` は state machine の error handling に流さないためである（[Error DSL の対象は `Exception` を境界にする](../adr/2026-05-01-error-dsl-exception-boundary.md)）。
+
+### `PluginScope`
+
+`PluginScope` は全 hook で使えるようにする。
+`onStart` だけに scope があると、後続 hook で使うために plugin 側が scope を保持する必要があり、不自然である。
+
+scope に入れるのは次の最小セットで十分である。
+
+- `currentState`
+  - 最新の committed state snapshot を読む
+- `dispatch(action)`
+  - 補助的な action を enqueue する
+- `launch { ... }`
+  - Store-scoped な background work を開始する
+
+`transaction`、`nextState`、`emit`、`cancelLaunch` のような権限は持たせない。
+そこまで入れると plugin が hidden handler や interceptor に寄り、責務が重くなりすぎる。
+
+### cleanup は `launch { try/finally }` に寄せる
+
+`Plugin` に `onClose` を入れる案も考えられるが、現状では採らない。
+
+理由は、`Store.close()` だけが Store の終了経路ではないためである。
+Store の root scope は親 `Job` にぶら下がっているため、親 scope 側の cancellation でも終了しうる。
+`onClose` を `Store.close()` からだけ呼ぶと、「明示 close」は拾えても、「Store の lifetime が終わった」ことまでは拾えない。
+
+そのため plugin 側の cleanup は、明示的な close hook ではなく、`PluginScope.launch` で開始した coroutine の `finally` に寄せる方が自然である。
+
+```kt
+override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
+    scope.launch {
+        val subscription = bus.subscribe { message ->
+            scope.dispatch(...)
+        }
+
+        try {
+            awaitCancellation()
+        } finally {
+            subscription.dispose()
+        }
+    }
+}
+```
+
+この形なら、`Store.close()` でも親 scope cancel でも同じ cleanup が走る。
+cleanup の所有者が、その仕事自身の lifetime にぶら下がる点も分かりやすい。
+
+### execution policy は持たない
+
+`Plugin` には `MiddlewareExecutionPolicy` のような execution policy は、少なくとも現時点では持たせない。
+
+`Plugin` も `Middleware` と同じく、複数登録されても互いに独立した外側の拡張として作られることが多い。
+その意味では、「独立した plugin なら並行実行でもよい」という考え方自体は自然である。
+
+一方で、そこからすぐに `PluginExecutionPolicy` を public API として足す必要があるとは限らない。
+`Plugin` は `dispatch()` や `launch()` を全 hook で使えるため、`Middleware` より一段“動ける”拡張でもある。
+ここで policy を公開すると、順序、追加 dispatch の見え方、例外時のふるまいなど、利用者が考えるべき面が増えやすい。
+
+そのため、現時点では **「Plugin は独立した拡張として設計する」ことと、「execution policy を公開する」ことは分けて考える**。
+独立した plugin どうしが並行でも成立する、という設計思想は持ちつつも、surface としては余計な option を増やさない方を優先する。
+
+実装上は、当面 registration order で順に流してもよい。
+ただしこれは `Plugin` の本質的な価値ではなく、API を安定させるまでの単純な固定挙動として捉える。
+
+もし将来 plugin の実行順を surface として扱うなら、`middleware(...)` / `plugin(...)` の宣言順そのものを強い契約にするより、priority のような明示的な概念で表した方がよい。
+宣言順は setup の見た目に依存しやすく、後から並べ替えたときに意図せず挙動が変わりやすいためである。
+
+また、plugin 内の重い仕事や long-running work は、hook 自体の execution policy に頼るより `scope.launch { ... }` に逃がす方が素直である。
+
+`Middleware` の default を並行実行にする考え方は、「middleware 同士の順序依存を前提にしない」ためのものである（[Middleware 実行ポリシーは並行を標準にする](../adr/2026-04-23-middleware-execution-policy.md)）。
+`Plugin` にもその発想は一部当てはまるが、現時点では policy まで公開して揃える必要はない。
+
+## 未解決事項
+
+- `Plugin` を今後 `Middleware` の代替へ寄せていくか、並行して残し続けるかは未決定。
+- README やサンプルで、plugin の long-running work と cleanup を `launch { try/finally }` ベースでどこまで明示するかは未決定。
+- plugin hook の実行順を将来も registration order に固定するか、内部的に並行化する余地を残すかは未決定。
+- plugin の実行順を公開仕様にする場合、registration order ではなく priority のような形で表すかは未決定。
+- 将来、Store lifetime の終了理由そのものを観測したい要件が出た場合、`onClose` ではなく root `Job` completion ベースの別 hook を検討する余地はある。
+
+## 関連
+
+- [Middleware 実行ポリシーは並行を標準にする](../adr/2026-04-23-middleware-execution-policy.md)
+- [Error DSL の対象は `Exception` を境界にする](../adr/2026-05-01-error-dsl-exception-boundary.md)

--- a/doc/internal/notes/2026-05-02-plugin-design.md
+++ b/doc/internal/notes/2026-05-02-plugin-design.md
@@ -1,22 +1,18 @@
 # Plugin 設計メモ
 
-- 更新日: 2026-05-02
+- 更新日: 2026-05-06
 
 ## 背景
 
 Tart にはすでに `Middleware` があるが、hook 数が多く、`before/after` の internal lifecycle がそのまま public API に出ている。
 
 一方で、logging、analytics、message bridge、autosave、sync のような用途では、必ずしも `Middleware` と同じ粒度や性質の hook は要らない。
-必要なのは interception より、Store の開始、action、state 更新、event、recoverable error を外側から観測し、必要なら補助的な非同期処理や追加 dispatch を行える拡張点である。
-
 そのため、`Middleware` とは別に、より小さい surface を持つ `Plugin` を追加する方向で整理したい。
 
 今回の論点は次のとおり。
 
 - `Plugin` は何のための拡張点か
 - どの hook を公開するか
-- `close` hook を持つか
-- `Middleware` のような execution policy を持つか
 
 ## 現在の考え
 
@@ -27,7 +23,6 @@ Tart にはすでに `Middleware` があるが、hook 数が多く、`before/aft
 - logging や analytics の記録
 - message bus / websocket / push などの購読開始
 - state 更新後の保存や同期
-- recoverable error の報告
 - 補助的な action dispatch
 
 逆に、現在処理中の action を差し替える、握りつぶす、`nextState` を横から書き換える、といった interception は `Plugin` の責務にしない。
@@ -40,59 +35,63 @@ Tart にはすでに `Middleware` があるが、hook 数が多く、`before/aft
 interface Plugin<S : State, A : Action, E : Event> {
     suspend fun onStart(scope: PluginScope<S, A>, state: S) {}
     suspend fun onAction(scope: PluginScope<S, A>, state: S, action: A) {}
-    suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {}
+    suspend fun onState(scope: PluginScope<S, A>, prevState: S, state: S) {}
     suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {}
-    suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {}
 }
 
 interface PluginScope<S : State, A : Action> {
-    val currentState: S
-    fun dispatch(action: A)
     fun launch(
         dispatcher: CoroutineDispatcher? = null,
-        block: suspend CoroutineScope.() -> Unit,
+        block: suspend LaunchScope<S, A>.() -> Unit,
     )
+
+    interface LaunchScope<S : State, A : Action> {
+        val currentState: S
+        fun dispatch(action: A)
+    }
 }
 ```
 
-hook の位相は次のように揃える。
+hook の位相は、単に `before` / `after` を機械的に揃えるのではなく、**Store 境界のどちら側を観測するか**で揃える。
 
 - `onStart`
   - Store start 時
   - 初回 `enter {}` の前
 - `onAction`
   - action handler 開始前
-- `onStateChanged`
-  - state commit と save の後
+  - dispatch 試行を確実に拾う
+- `onState`
+  - state commit / save / observer 通知の後
 - `onEvent`
-  - event emit 前
-- `onError`
-  - recoverable error の handler 実行前
+  - event emit / observer 通知の後
 
-`onAction` / `onEvent` / `onError` は開始地点に寄せ、`onStateChanged` だけは更新後の hook とする。
-state type change を見たい場合は、`onStateChanged` の中で `prevState::class != state::class` を見れば足りるので、専用 hook は持たない。
+この整理では、
 
-名前を `onState` ではなく `onStateChanged` にしているのは、`StoreObserver.onState(state)` と契約が異なるためである。
-observer の `onState` は「Store が state snapshot を observer に見せる」通知であり、attach 時の設定によっては start 前の current state を即時に受け取ることもある。
-一方 plugin 側で欲しいのは「新しい state が commit され、保存まで済んだ」という更新通知であり、`prevState` も必要になる。
-同じ `onState` という名前にすると、snapshot 観測と committed update 観測の違いが見えにくくなるため、plugin 側は `onStateChanged` として分ける。
+- `onAction`
+  - Store への **入力** を観測する hook なので事前
+- `onState`
+  - Store から確定した state という **出力** を観測する hook なので事後
+- `onEvent`
+  - Store から emit された event という **出力** を観測する hook なので事後
 
-`onError` の型は `Throwable` ではなく `Exception` とする。
-Tart の recoverable error path は `Exception` に限定されており、`CancellationException` やそれ以外の `Throwable` は state machine の error handling に流さないためである（[Error DSL の対象は `Exception` を境界にする](../adr/2026-05-01-error-dsl-exception-boundary.md)）。
+となる。
+
+`onStart` は input/output のどちらにも属さないため、別種の lifecycle hook として扱う。
+state type change を見たい場合は、`onState` の中で `prevState::class != state::class` を見れば足りるので、専用 hook は持たない。
 
 ### `PluginScope`
 
-`PluginScope` は全 hook で使えるようにする。
-`onStart` だけに scope があると、後続 hook で使うために plugin 側が scope を保持する必要があり、不自然である。
+`PluginScope` 自体は全 hook で使えるようにする。
+ただし、hook 本体では観測に寄せ、追加の権限は `launch {}` の中に閉じ込める。
 
 scope に入れるのは次の最小セットで十分である。
 
-- `currentState`
-  - 最新の committed state snapshot を読む
-- `dispatch(action)`
-  - 補助的な action を enqueue する
 - `launch { ... }`
   - Store-scoped な background work を開始する
+- `launch {}` 内の `LaunchScope.currentState`
+  - 遅れて動く処理が最新の committed state snapshot を読む
+- `launch {}` 内の `LaunchScope.dispatch(action)`
+  - background work から補助的な action を enqueue する
 
 `transaction`、`nextState`、`emit`、`cancelLaunch` のような権限は持たせない。
 そこまで入れると plugin が hidden handler や interceptor に寄り、責務が重くなりすぎる。
@@ -111,7 +110,7 @@ Store の root scope は親 `Job` にぶら下がっているため、親 scope 
 override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
     scope.launch {
         val subscription = bus.subscribe { message ->
-            scope.dispatch(...)
+            dispatch(...)
         }
 
         try {
@@ -126,40 +125,43 @@ override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
 この形なら、`Store.close()` でも親 scope cancel でも同じ cleanup が走る。
 cleanup の所有者が、その仕事自身の lifetime にぶら下がる点も分かりやすい。
 
-### execution policy は持たない
+### execution policy は持つ
 
-`Plugin` には `MiddlewareExecutionPolicy` のような execution policy は、少なくとも現時点では持たせない。
+`Plugin` には `PluginExecutionPolicy` を持たせる。
+default は `Concurrent` とし、必要なときだけ `InRegistrationOrder` を選べるようにする。
 
-`Plugin` も `Middleware` と同じく、複数登録されても互いに独立した外側の拡張として作られることが多い。
-その意味では、「独立した plugin なら並行実行でもよい」という考え方自体は自然である。
+この方針の理由は、`Plugin` も `Middleware` と同じく、複数登録されても互いに独立した外側の拡張として作られることが多いためである。
+特に現在の `Plugin` は観測ベースであり、
 
-一方で、そこからすぐに `PluginExecutionPolicy` を public API として足す必要があるとは限らない。
-`Plugin` は `dispatch()` や `launch()` を全 hook で使えるため、`Middleware` より一段“動ける”拡張でもある。
-ここで policy を公開すると、順序、追加 dispatch の見え方、例外時のふるまいなど、利用者が考えるべき面が増えやすい。
+- `onAction` は入力 hook
+- `onState` / `onEvent` は出力 hook
 
-そのため、現時点では **「Plugin は独立した拡張として設計する」ことと、「execution policy を公開する」ことは分けて考える**。
-独立した plugin どうしが並行でも成立する、という設計思想は持ちつつも、surface としては余計な option を増やさない方を優先する。
+という整理になっている。
+この性質なら、plugin は原則として順序非依存で書けるはずであり、default を `Concurrent` にする考え方と相性がよい。
 
-実装上は、当面 registration order で順に流してもよい。
-ただしこれは `Plugin` の本質的な価値ではなく、API を安定させるまでの単純な固定挙動として捉える。
+一方で、移行期の互換性や、特定の setup で順序を意識したいケースまで完全に否定する必要もない。
+そのため、escape hatch として `InRegistrationOrder` を残す。
 
-もし将来 plugin の実行順を surface として扱うなら、`middleware(...)` / `plugin(...)` の宣言順そのものを強い契約にするより、priority のような明示的な概念で表した方がよい。
-宣言順は setup の見た目に依存しやすく、後から並べ替えたときに意図せず挙動が変わりやすいためである。
+ただし、`InRegistrationOrder` は通常系ではなく例外的な選択肢として扱う。
+reusable な plugin は、基本的に `Concurrent` 前提でも安全に動くことを目指す。
 
 また、plugin 内の重い仕事や long-running work は、hook 自体の execution policy に頼るより `scope.launch { ... }` に逃がす方が素直である。
+そのため execution policy が制御するのは、あくまで **hook 呼び出し自体の順序** に限られる。
+background work の完了順や、そこで起こした `dispatch()` の interleave までは保証しない。
 
 `Middleware` の default を並行実行にする考え方は、「middleware 同士の順序依存を前提にしない」ためのものである（[Middleware 実行ポリシーは並行を標準にする](../adr/2026-04-23-middleware-execution-policy.md)）。
-`Plugin` にもその発想は一部当てはまるが、現時点では policy まで公開して揃える必要はない。
+`Plugin` でも同じく、「plugin はまず順序非依存であるべき」と考えて `Concurrent` を標準にする。
+
+もし将来、利用者が本当に欲しいのが「この plugin を先に走らせたい」「この plugin 群は後段で見たい」という制御であるなら、`Concurrent` / `InRegistrationOrder` の二択より、priority や phase のような明示的な概念の方が本質に近い。
+そのため execution policy を導入しても、将来の順序制御までこれで十分だとはみなさない。
 
 ## 未解決事項
 
 - `Plugin` を今後 `Middleware` の代替へ寄せていくか、並行して残し続けるかは未決定。
 - README やサンプルで、plugin の long-running work と cleanup を `launch { try/finally }` ベースでどこまで明示するかは未決定。
-- plugin hook の実行順を将来も registration order に固定するか、内部的に並行化する余地を残すかは未決定。
-- plugin の実行順を公開仕様にする場合、registration order ではなく priority のような形で表すかは未決定。
+- plugin の execution policy を将来も `Concurrent` / `InRegistrationOrder` の二択に留めるか、priority / phase のような別概念を追加するかは未決定。
 - 将来、Store lifetime の終了理由そのものを観測したい要件が出た場合、`onClose` ではなく root `Job` completion ベースの別 hook を検討する余地はある。
 
 ## 関連
 
 - [Middleware 実行ポリシーは並行を標準にする](../adr/2026-04-23-middleware-execution-policy.md)
-- [Error DSL の対象は `Exception` を境界にする](../adr/2026-05-01-error-dsl-exception-boundary.md)

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareScope.kt
@@ -23,7 +23,8 @@ interface MiddlewareScope<A : Action> {
     /**
      * Starts background work in the Store's root coroutine scope and returns immediately.
      *
-     * The launched coroutine survives state changes and is cancelled only when the Store is closed.
+     * The launched coroutine survives state changes and is cancelled when the Store's root
+     * coroutine scope is cancelled, such as by [Store.close] or parent scope cancellation.
      *
      * @param dispatcher Optional CoroutineDispatcher override for the coroutine.
      * When null, the coroutine inherits the Store's current execution context.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt
@@ -1,19 +1,17 @@
 package io.yumemi.tart.core
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-
 /**
- * Extension point for reacting to Store lifecycle events such as startup, actions, committed
- * state changes, event emission, and error handling.
+ * Extension point for reacting to Store lifecycle events such as startup, dispatched actions,
+ * committed state snapshots, and emitted events.
  *
- * Plugin hooks are suspending functions and are awaited by the Store before it continues
- * processing. Long-running work in a hook can delay Store processing. When work should continue
- * in the background, start it from a hook using [PluginScope.launch].
+ * Plugin hooks are suspending functions and are awaited by the Store according to the configured
+ * [PluginExecutionPolicy] before it continues processing. Long-running work in a hook can delay
+ * Store processing. When work should continue in the background, start it from a hook using
+ * [PluginScope.launch].
  */
 interface Plugin<S : State, A : Action, E : Event> {
     /**
-     * Called once when the Store starts, before the initial `enter {}` processing runs.
+     * Called once when Store startup begins, before the initial `enter {}` processing starts.
      */
     suspend fun onStart(scope: PluginScope<S, A>, state: S) {}
 
@@ -23,19 +21,14 @@ interface Plugin<S : State, A : Action, E : Event> {
     suspend fun onAction(scope: PluginScope<S, A>, state: S, action: A) {}
 
     /**
-     * Called after a new state snapshot is committed and persisted.
+     * Called after a new state snapshot is committed, persisted, and reported to observers.
      */
-    suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {}
+    suspend fun onState(scope: PluginScope<S, A>, prevState: S, state: S) {}
 
     /**
-     * Called before an event is emitted to collectors and observers.
+     * Called after an event is emitted to collectors and observers.
      */
     suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {}
-
-    /**
-     * Called before a matching `error {}` handler runs for a non-fatal [Exception].
-     */
-    suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {}
 }
 
 /**
@@ -44,22 +37,22 @@ interface Plugin<S : State, A : Action, E : Event> {
  * These callbacks are suspending and are awaited by the Store just like a custom
  * [Plugin] implementation.
  *
- * All callbacks use [PluginScope] as the receiver so they can inspect the latest committed
- * state, dispatch additional actions, or launch Store-scoped background work without having
- * to capture the scope manually.
+ * All callbacks use [PluginScope] as the receiver so they can start Store-scoped background
+ * work without having to capture the scope manually.
+ * Additional capabilities such as reading the latest committed state snapshot or dispatching
+ * actions are available only inside [PluginScope.launch].
  *
- * @param onStart Function called when the Store starts
+ * @param onStart Function called when Store startup begins, before the initial `enter {}`
+ * processing starts
  * @param onAction Function called before an action handler starts
- * @param onStateChanged Function called after a state snapshot is committed and persisted
- * @param onEvent Function called before an event is emitted
- * @param onError Function called before an error handler runs
+ * @param onState Function called after a state snapshot is committed and persisted
+ * @param onEvent Function called after an event is emitted
  */
 fun <S : State, A : Action, E : Event> Plugin(
     onStart: suspend PluginScope<S, A>.(S) -> Unit = {},
     onAction: suspend PluginScope<S, A>.(S, A) -> Unit = { _, _ -> },
-    onStateChanged: suspend PluginScope<S, A>.(S, S) -> Unit = { _, _ -> },
+    onState: suspend PluginScope<S, A>.(S, S) -> Unit = { _, _ -> },
     onEvent: suspend PluginScope<S, A>.(S, E) -> Unit = { _, _ -> },
-    onError: suspend PluginScope<S, A>.(S, Exception) -> Unit = { _, _ -> },
 ) = object : Plugin<S, A, E> {
     override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
         scope.onStart(state)
@@ -69,46 +62,11 @@ fun <S : State, A : Action, E : Event> Plugin(
         scope.onAction(state, action)
     }
 
-    override suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {
-        scope.onStateChanged(prevState, state)
+    override suspend fun onState(scope: PluginScope<S, A>, prevState: S, state: S) {
+        scope.onState(prevState, state)
     }
 
     override suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {
         scope.onEvent(state, event)
     }
-
-    override suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {
-        scope.onError(state, error)
-    }
-}
-
-/**
- * Scope exposed to [Plugin] hooks.
- *
- * Plugins can use this scope to inspect the latest committed state snapshot, dispatch additional
- * actions, or start Store-scoped background work.
- */
-interface PluginScope<S : State, A : Action> {
-    /**
-     * The latest committed state snapshot.
-     *
-     * This value may change immediately after it is read if other Store work commits a new state.
-     */
-    val currentState: S
-
-    /**
-     * Dispatches an action to the Store.
-     *
-     * This enqueues the action and returns immediately.
-     * It does not wait for action handling to complete.
-     */
-    fun dispatch(action: A)
-
-    /**
-     * Starts background work in the Store's root coroutine scope and returns immediately.
-     *
-     * The launched coroutine survives state changes and is cancelled when the Store's root
-     * coroutine scope is cancelled, such as by [Store.close] or parent scope cancellation.
-     */
-    fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend CoroutineScope.() -> Unit)
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt
@@ -1,0 +1,114 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Extension point for reacting to Store lifecycle events such as startup, actions, committed
+ * state changes, event emission, and error handling.
+ *
+ * Plugin hooks are suspending functions and are awaited by the Store before it continues
+ * processing. Long-running work in a hook can delay Store processing. When work should continue
+ * in the background, start it from a hook using [PluginScope.launch].
+ */
+interface Plugin<S : State, A : Action, E : Event> {
+    /**
+     * Called once when the Store starts, before the initial `enter {}` processing runs.
+     */
+    suspend fun onStart(scope: PluginScope<S, A>, state: S) {}
+
+    /**
+     * Called before an action handler starts processing the dispatched action.
+     */
+    suspend fun onAction(scope: PluginScope<S, A>, state: S, action: A) {}
+
+    /**
+     * Called after a new state snapshot is committed and persisted.
+     */
+    suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {}
+
+    /**
+     * Called before an event is emitted to collectors and observers.
+     */
+    suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {}
+
+    /**
+     * Called before a matching `error {}` handler runs for a non-fatal [Exception].
+     */
+    suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {}
+}
+
+/**
+ * Creates a [Plugin] from individual lifecycle callbacks.
+ *
+ * These callbacks are suspending and are awaited by the Store just like a custom
+ * [Plugin] implementation.
+ *
+ * All callbacks use [PluginScope] as the receiver so they can inspect the latest committed
+ * state, dispatch additional actions, or launch Store-scoped background work without having
+ * to capture the scope manually.
+ *
+ * @param onStart Function called when the Store starts
+ * @param onAction Function called before an action handler starts
+ * @param onStateChanged Function called after a state snapshot is committed and persisted
+ * @param onEvent Function called before an event is emitted
+ * @param onError Function called before an error handler runs
+ */
+fun <S : State, A : Action, E : Event> Plugin(
+    onStart: suspend PluginScope<S, A>.(S) -> Unit = {},
+    onAction: suspend PluginScope<S, A>.(S, A) -> Unit = { _, _ -> },
+    onStateChanged: suspend PluginScope<S, A>.(S, S) -> Unit = { _, _ -> },
+    onEvent: suspend PluginScope<S, A>.(S, E) -> Unit = { _, _ -> },
+    onError: suspend PluginScope<S, A>.(S, Exception) -> Unit = { _, _ -> },
+) = object : Plugin<S, A, E> {
+    override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
+        scope.onStart(state)
+    }
+
+    override suspend fun onAction(scope: PluginScope<S, A>, state: S, action: A) {
+        scope.onAction(state, action)
+    }
+
+    override suspend fun onStateChanged(scope: PluginScope<S, A>, prevState: S, state: S) {
+        scope.onStateChanged(prevState, state)
+    }
+
+    override suspend fun onEvent(scope: PluginScope<S, A>, state: S, event: E) {
+        scope.onEvent(state, event)
+    }
+
+    override suspend fun onError(scope: PluginScope<S, A>, state: S, error: Exception) {
+        scope.onError(state, error)
+    }
+}
+
+/**
+ * Scope exposed to [Plugin] hooks.
+ *
+ * Plugins can use this scope to inspect the latest committed state snapshot, dispatch additional
+ * actions, or start Store-scoped background work.
+ */
+interface PluginScope<S : State, A : Action> {
+    /**
+     * The latest committed state snapshot.
+     *
+     * This value may change immediately after it is read if other Store work commits a new state.
+     */
+    val currentState: S
+
+    /**
+     * Dispatches an action to the Store.
+     *
+     * This enqueues the action and returns immediately.
+     * It does not wait for action handling to complete.
+     */
+    fun dispatch(action: A)
+
+    /**
+     * Starts background work in the Store's root coroutine scope and returns immediately.
+     *
+     * The launched coroutine survives state changes and is cancelled when the Store's root
+     * coroutine scope is cancelled, such as by [Store.close] or parent scope cancellation.
+     */
+    fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend CoroutineScope.() -> Unit)
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginExecutionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginExecutionPolicy.kt
@@ -1,0 +1,16 @@
+package io.yumemi.tart.core
+
+/**
+ * Controls how the Store invokes plugins when multiple plugins are registered.
+ */
+enum class PluginExecutionPolicy {
+    /**
+     * Invokes plugin hooks concurrently and waits until all of them complete.
+     */
+    Concurrent,
+
+    /**
+     * Invokes plugin hooks one by one in registration order.
+     */
+    InRegistrationOrder,
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginScope.kt
@@ -1,0 +1,43 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Scope exposed to [Plugin] hooks.
+ *
+ * Plugins can use this scope to start Store-scoped background work.
+ */
+interface PluginScope<S : State, A : Action> {
+    /**
+     * Starts background work in the Store's root coroutine scope and returns immediately.
+     *
+     * The launched coroutine survives state changes and is cancelled when the Store's root
+     * coroutine scope is cancelled, such as by [Store.close] or parent scope cancellation.
+     */
+    fun launch(dispatcher: CoroutineDispatcher? = null, block: suspend PluginLaunchScope<S, A>.() -> Unit)
+
+    /**
+     * Scope available within background work launched from a [Plugin].
+     */
+    interface LaunchScope<S : State, A : Action> {
+        /**
+         * The latest committed state snapshot.
+         *
+         * This value may change immediately after it is read if other Store work commits a new state.
+         */
+        val currentState: S
+
+        /**
+         * Dispatches an action to the Store.
+         *
+         * This enqueues the action and returns immediately.
+         * It does not wait for action handling to complete.
+         */
+        fun dispatch(action: A)
+    }
+}
+
+/**
+ * Flattened alias for [PluginScope.LaunchScope] to keep public signatures concise in IDE tooltips.
+ */
+typealias PluginLaunchScope<S, A> = PluginScope.LaunchScope<S, A>

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -91,7 +91,8 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     /**
      * Cancels the Store and releases its resources.
      *
-     * Active state-scoped coroutines, middleware coroutines, and callback collectors are cancelled.
+     * Active state-scoped coroutines, plugin coroutines, middleware coroutines, and callback
+     * collectors are cancelled.
      */
     override fun close()
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -20,6 +20,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
     private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit
     private var storeMiddlewareExecutionPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.Concurrent
+    private var storePlugins: MutableList<Plugin<S, A, E>> = mutableListOf()
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**
@@ -83,6 +84,29 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
      */
     fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
         storeMiddlewareExecutionPolicy = policy
+    }
+
+    /**
+     * Appends one or more plugins to the Store.
+     *
+     * Plugins are invoked one by one in registration order.
+     *
+     * @param first The first plugin instance to add
+     * @param rest Additional plugin instances to add
+     */
+    fun plugin(first: Plugin<S, A, E>, vararg rest: Plugin<S, A, E>) {
+        storePlugins.add(first)
+        storePlugins.addAll(rest)
+    }
+
+    internal fun clearPlugins() {
+        storePlugins.clear()
+    }
+
+    internal fun replacePlugins(first: Plugin<S, A, E>, vararg rest: Plugin<S, A, E>) {
+        clearPlugins()
+        storePlugins.add(first)
+        storePlugins.addAll(rest)
     }
 
     /**
@@ -306,6 +330,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
             override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
             override val middlewareExecutionPolicy: MiddlewareExecutionPolicy = storeMiddlewareExecutionPolicy
+            override val plugins: List<Plugin<S, A, E>> = storePlugins
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
             override val onEnter: suspend EnterScope<S, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
@@ -324,7 +349,7 @@ typealias Setup<S, A, E> = StoreBuilder<S, A, E>.() -> Unit
  * Store overrides block applied after the main [Setup] block.
  *
  * This block is limited to non-state configuration such as coroutine context, persistence,
- * exception handling, pending action policy, and middleware.
+ * exception handling, pending action policy, plugins, and middleware.
  */
 typealias Overrides<S, A, E> = StoreOverridesBuilder<S, A, E>.() -> Unit
 
@@ -372,6 +397,33 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
      */
     fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
         operations.add { middlewareExecutionPolicy(policy) }
+    }
+
+    /**
+     * Appends plugins after the main setup block has run.
+     */
+    fun plugin(first: Plugin<S, A, E>, vararg rest: Plugin<S, A, E>) {
+        val restValues = rest.copyOf()
+        operations.add { plugin(first, *restValues) }
+    }
+
+    /**
+     * Replaces every plugin configured so far.
+     *
+     * This is useful for removing default plugins in tests or debug setups.
+     */
+    fun replacePlugins(first: Plugin<S, A, E>, vararg rest: Plugin<S, A, E>) {
+        val restValues = rest.copyOf()
+        operations.add { replacePlugins(first, *restValues) }
+    }
+
+    /**
+     * Removes every plugin configured so far.
+     *
+     * This is useful for removing default plugins in tests or debug setups.
+     */
+    fun clearPlugins() {
+        operations.add { clearPlugins() }
     }
 
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -19,6 +19,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
     private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit
+    private var storePluginExecutionPolicy: PluginExecutionPolicy = PluginExecutionPolicy.Concurrent
     private var storeMiddlewareExecutionPolicy: MiddlewareExecutionPolicy = MiddlewareExecutionPolicy.Concurrent
     private var storePlugins: MutableList<Plugin<S, A, E>> = mutableListOf()
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
@@ -87,9 +88,19 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     }
 
     /**
-     * Appends one or more plugins to the Store.
+     * Sets how the Store invokes plugins when multiple plugin instances are registered.
      *
-     * Plugins are invoked one by one in registration order.
+     * Regardless of policy, the Store waits for all matching plugin hooks to complete before it
+     * continues processing.
+     *
+     * @param policy The plugin execution policy to use
+     */
+    fun pluginExecutionPolicy(policy: PluginExecutionPolicy) {
+        storePluginExecutionPolicy = policy
+    }
+
+    /**
+     * Appends one or more plugins to the Store.
      *
      * @param first The first plugin instance to add
      * @param rest Additional plugin instances to add
@@ -329,6 +340,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val stateSaver: StateSaver<S> = storeStateSaver
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
             override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
+            override val pluginExecutionPolicy: PluginExecutionPolicy = storePluginExecutionPolicy
             override val middlewareExecutionPolicy: MiddlewareExecutionPolicy = storeMiddlewareExecutionPolicy
             override val plugins: List<Plugin<S, A, E>> = storePlugins
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
@@ -397,6 +409,13 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
      */
     fun middlewareExecutionPolicy(policy: MiddlewareExecutionPolicy) {
         operations.add { middlewareExecutionPolicy(policy) }
+    }
+
+    /**
+     * Overrides how the Store invokes plugins when multiple plugin instances are registered.
+     */
+    fun pluginExecutionPolicy(policy: PluginExecutionPolicy) {
+        operations.add { pluginExecutionPolicy(policy) }
     }
 
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -76,6 +75,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val pendingActionPolicy: PendingActionPolicy
 
+    protected abstract val pluginExecutionPolicy: PluginExecutionPolicy
+
     protected abstract val middlewareExecutionPolicy: MiddlewareExecutionPolicy
 
     protected abstract val plugins: List<Plugin<S, A, E>>
@@ -106,15 +107,17 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private val pluginScope by lazy {
         object : PluginScope<S, A> {
-            override val currentState: S get() = this@StoreImpl.currentState
-
-            override fun dispatch(action: A) {
-                this@StoreImpl.dispatch(action)
-            }
-
-            override fun launch(dispatcher: CoroutineDispatcher?, block: suspend CoroutineScope.() -> Unit) {
+            override fun launch(dispatcher: CoroutineDispatcher?, block: suspend PluginLaunchScope<S, A>.() -> Unit) {
                 coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
-                    block()
+                    block(
+                        object : PluginLaunchScope<S, A> {
+                            override val currentState: S get() = this@StoreImpl.currentState
+
+                            override fun dispatch(action: A) {
+                                this@StoreImpl.dispatch(action)
+                            }
+                        },
+                    )
                 }
             }
         }
@@ -658,14 +661,13 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             rethrowIfNonRecoverable(t)
             throw InternalError(t)
         }
-        processPlugins { onStateChanged(pluginScope, state, nextState) }
         notifyStateRecorded(nextState)
         processMiddleware { afterStateChange(nextState, state) }
+        processPlugins { onState(pluginScope, state, nextState) }
     }
 
     private suspend fun processError(state: S, throwable: Exception): S {
         processMiddleware { beforeError(state, throwable) }
-        processPlugins { onError(pluginScope, state, throwable) }
         var newState: S? = null
         onError.invoke(
             object : ErrorScope<S, E, S, Exception> {
@@ -695,10 +697,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun processEventEmit(state: S, event: E) {
         processMiddleware { beforeEventEmit(state, event) }
-        processPlugins { onEvent(pluginScope, state, event) }
         _event.emit(event)
         notifyEventRecorded(event)
         processMiddleware { afterEventEmit(state, event) }
+        processPlugins { onEvent(pluginScope, state, event) }
     }
 
     private fun clearPendingActionsOnStateExitIfNeeded() {
@@ -736,8 +738,16 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun processPlugins(block: suspend Plugin<S, A, E>.() -> Unit) {
         try {
-            plugins.forEach { plugin ->
-                plugin.block()
+            when (pluginExecutionPolicy) {
+                PluginExecutionPolicy.Concurrent -> coroutineScope {
+                    plugins.forEach { plugin ->
+                        launch { plugin.block() }
+                    }
+                }
+
+                PluginExecutionPolicy.InRegistrationOrder -> plugins.forEach { plugin ->
+                    plugin.block()
+                }
             }
         } catch (t: Throwable) {
             rethrowIfNonRecoverable(t)

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -78,6 +78,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val middlewareExecutionPolicy: MiddlewareExecutionPolicy
 
+    protected abstract val plugins: List<Plugin<S, A, E>>
+
     protected abstract val middlewares: List<Middleware<S, A, E>>
 
     protected abstract val onEnter: suspend EnterScope<S, E, S>.() -> Unit
@@ -100,6 +102,22 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         CoroutineScope(
             coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job]),
         )
+    }
+
+    private val pluginScope by lazy {
+        object : PluginScope<S, A> {
+            override val currentState: S get() = this@StoreImpl.currentState
+
+            override fun dispatch(action: A) {
+                this@StoreImpl.dispatch(action)
+            }
+
+            override fun launch(dispatcher: CoroutineDispatcher?, block: suspend CoroutineScope.() -> Unit) {
+                coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
+                    block()
+                }
+            }
+        }
     }
 
     private val mutex = Mutex()
@@ -190,6 +208,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 currentState,
             )
         }
+        processPlugins { onStart(pluginScope, currentState) }
         onStateEntered(currentState)
     }
 
@@ -296,6 +315,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun processActionDispatch(state: S, action: A): S {
         processMiddleware { beforeActionDispatch(state, action) }
+        processPlugins { onAction(pluginScope, state, action) }
         var newState: S? = null
         onAction.invoke(
             object : ActionScope<S, A, E, S> {
@@ -638,12 +658,14 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             rethrowIfNonRecoverable(t)
             throw InternalError(t)
         }
+        processPlugins { onStateChanged(pluginScope, state, nextState) }
         notifyStateRecorded(nextState)
         processMiddleware { afterStateChange(nextState, state) }
     }
 
     private suspend fun processError(state: S, throwable: Exception): S {
         processMiddleware { beforeError(state, throwable) }
+        processPlugins { onError(pluginScope, state, throwable) }
         var newState: S? = null
         onError.invoke(
             object : ErrorScope<S, E, S, Exception> {
@@ -673,6 +695,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private suspend fun processEventEmit(state: S, event: E) {
         processMiddleware { beforeEventEmit(state, event) }
+        processPlugins { onEvent(pluginScope, state, event) }
         _event.emit(event)
         notifyEventRecorded(event)
         processMiddleware { afterEventEmit(state, event) }
@@ -704,6 +727,17 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 MiddlewareExecutionPolicy.InRegistrationOrder -> middlewares.forEach { middleware ->
                     middleware.block()
                 }
+            }
+        } catch (t: Throwable) {
+            rethrowIfNonRecoverable(t)
+            throw InternalError(t)
+        }
+    }
+
+    private suspend fun processPlugins(block: suspend Plugin<S, A, E>.() -> Unit) {
+        try {
+            plugins.forEach { plugin ->
+                plugin.block()
             }
         } catch (t: Throwable) {
             rethrowIfNonRecoverable(t)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
@@ -53,6 +53,17 @@ class StoreOverridesTest {
         )
     }
 
+    private fun recordingPlugin(
+        name: String,
+        records: MutableList<String>,
+    ): Plugin<AppState, AppAction, Nothing> {
+        return Plugin(
+            onAction = { _, _ ->
+                records += name
+            },
+        )
+    }
+
     @Test
     fun storeInitialStateOverload_shouldApplyOverridesAfterSetup() {
         val setupSaver = RecordingStateSaver(restoredState = AppState(count = 100))
@@ -146,6 +157,56 @@ class StoreOverridesTest {
     }
 
     @Test
+    fun replacePluginsInOverrides_shouldReplacePreviouslyConfiguredPlugins() {
+        val pluginRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                replacePlugins(recordingPlugin("override", pluginRecords))
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            plugin(recordingPlugin("setup", pluginRecords))
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(listOf("override"), pluginRecords)
+    }
+
+    @Test
+    fun clearPluginsInOverrides_shouldClearPreviouslyConfiguredPlugins() {
+        val pluginRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                clearPlugins()
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            plugin(recordingPlugin("setup", pluginRecords))
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertTrue(pluginRecords.isEmpty())
+    }
+
+    @Test
     fun middleware_shouldAcceptMultipleValuesInSetupAndOverrides() {
         val middlewareRecords = mutableListOf<String>()
 
@@ -176,6 +237,40 @@ class StoreOverridesTest {
         assertEquals(
             listOf("override1", "override2", "setup1", "setup2"),
             middlewareRecords.sorted(),
+        )
+    }
+
+    @Test
+    fun plugin_shouldAcceptMultipleValuesInSetupAndOverrides() {
+        val pluginRecords = mutableListOf<String>()
+
+        val store = Store(
+            initialState = AppState(count = 0),
+            overrides = {
+                plugin(
+                    recordingPlugin("override1", pluginRecords),
+                    recordingPlugin("override2", pluginRecords),
+                )
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            plugin(
+                recordingPlugin("setup1", pluginRecords),
+                recordingPlugin("setup2", pluginRecords),
+            )
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(
+            listOf("setup1", "setup2", "override1", "override2"),
+            pluginRecords,
         )
     }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExceptionTest.kt
@@ -75,26 +75,26 @@ class StorePluginExceptionTest {
     }
 
     @Test
-    fun pluginOnErrorException_isHandledWithoutRetryingStoreErrorHandling() = runTest(testDispatcher) {
+    fun pluginOnStateException_isHandledWithoutRetryingStoreErrorHandling() = runTest(testDispatcher) {
         var handledException: Throwable? = null
         val store = createStore(
             plugin = object : Plugin<AppState, AppAction, Nothing> {
-                override suspend fun onError(
+                override suspend fun onState(
                     scope: PluginScope<AppState, AppAction>,
+                    prevState: AppState,
                     state: AppState,
-                    error: Exception,
                 ) {
-                    throw IllegalArgumentException("onError failed")
+                    throw IllegalArgumentException("onState failed")
                 }
             },
             exceptionHandler = ExceptionHandler { handledException = it },
         )
 
-        store.dispatch(AppAction.Throw)
+        store.dispatch(AppAction.Increment)
         testScheduler.runCurrent()
 
-        assertEquals(AppState.Ready(), store.currentState)
+        assertEquals(AppState.Ready(value = 1), store.currentState)
         val error = assertIs<IllegalArgumentException>(handledException)
-        assertEquals("onError failed", error.message)
+        assertEquals("onState failed", error.message)
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExceptionTest.kt
@@ -1,0 +1,100 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorePluginExceptionTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    sealed interface AppState : State {
+        data class Ready(val value: Int = 0) : AppState
+        data class Failed(val message: String) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object Throw : AppAction
+    }
+
+    private fun createStore(
+        plugin: Plugin<AppState, AppAction, Nothing>,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(AppState.Ready()) {
+            coroutineContext(Dispatchers.Unconfined)
+            exceptionHandler(exceptionHandler)
+            plugin(plugin)
+
+            state<AppState.Ready> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(value = state.value + 1))
+                }
+
+                action<AppAction.Throw> {
+                    throw IllegalStateException("action failed")
+                }
+            }
+
+            state<AppState> {
+                error<Exception> {
+                    nextState(AppState.Failed(error.message ?: "unknown"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun pluginException_isHandledWithoutUsingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createStore(
+            plugin = object : Plugin<AppState, AppAction, Nothing> {
+                override suspend fun onAction(
+                    scope: PluginScope<AppState, AppAction>,
+                    state: AppState,
+                    action: AppAction,
+                ) {
+                    throw IllegalArgumentException("plugin failed")
+                }
+            },
+            exceptionHandler = ExceptionHandler { handledException = it },
+        )
+
+        store.dispatch(AppAction.Increment)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Ready(), store.currentState)
+        val error = assertIs<IllegalArgumentException>(handledException)
+        assertEquals("plugin failed", error.message)
+    }
+
+    @Test
+    fun pluginOnErrorException_isHandledWithoutRetryingStoreErrorHandling() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+        val store = createStore(
+            plugin = object : Plugin<AppState, AppAction, Nothing> {
+                override suspend fun onError(
+                    scope: PluginScope<AppState, AppAction>,
+                    state: AppState,
+                    error: Exception,
+                ) {
+                    throw IllegalArgumentException("onError failed")
+                }
+            },
+            exceptionHandler = ExceptionHandler { handledException = it },
+        )
+
+        store.dispatch(AppAction.Throw)
+        testScheduler.runCurrent()
+
+        assertEquals(AppState.Ready(), store.currentState)
+        val error = assertIs<IllegalArgumentException>(handledException)
+        assertEquals("onError failed", error.message)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExecutionPolicyTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginExecutionPolicyTest.kt
@@ -1,0 +1,169 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorePluginExecutionPolicyTest {
+
+    data class AppState(val count: Int = 0) : State
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+    }
+
+    private fun createStore(
+        testDispatcher: TestDispatcher,
+        records: MutableList<String>,
+        firstPluginStarted: CompletableDeferred<Unit>,
+        secondPluginStarted: CompletableDeferred<Unit>,
+        firstPluginCanFinish: CompletableDeferred<Unit>,
+        setupPolicy: PluginExecutionPolicy = PluginExecutionPolicy.Concurrent,
+        overrides: Overrides<AppState, AppAction, Nothing> = {},
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(
+            initialState = AppState(),
+            overrides = overrides,
+        ) {
+            coroutineContext(testDispatcher)
+            pluginExecutionPolicy(setupPolicy)
+
+            plugin(
+                Plugin(
+                    onAction = { _, _ ->
+                        records += "first:start"
+                        firstPluginStarted.complete(Unit)
+                        firstPluginCanFinish.await()
+                        records += "first:end"
+                    },
+                ),
+                Plugin(
+                    onAction = { _, _ ->
+                        records += "second:start"
+                        secondPluginStarted.complete(Unit)
+                        records += "second:end"
+                    },
+                ),
+            )
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun concurrent_isDefaultAndAllowsOtherPluginsToRunWhileOneIsSuspended() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstPluginStarted = CompletableDeferred<Unit>()
+        val secondPluginStarted = CompletableDeferred<Unit>()
+        val firstPluginCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstPluginStarted = firstPluginStarted,
+            secondPluginStarted = secondPluginStarted,
+            firstPluginCanFinish = firstPluginCanFinish,
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstPluginStarted.isCompleted)
+        assertTrue(secondPluginStarted.isCompleted)
+        assertEquals(
+            listOf("first:start", "second:start", "second:end"),
+            records,
+        )
+
+        firstPluginCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "second:start", "second:end", "first:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+
+    @Test
+    fun inRegistrationOrder_waitsForPreviousPluginToFinishBeforeStartingNextOne() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstPluginStarted = CompletableDeferred<Unit>()
+        val secondPluginStarted = CompletableDeferred<Unit>()
+        val firstPluginCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstPluginStarted = firstPluginStarted,
+            secondPluginStarted = secondPluginStarted,
+            firstPluginCanFinish = firstPluginCanFinish,
+            setupPolicy = PluginExecutionPolicy.InRegistrationOrder,
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstPluginStarted.isCompleted)
+        assertFalse(secondPluginStarted.isCompleted)
+        assertEquals(listOf("first:start"), records)
+
+        firstPluginCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "first:end", "second:start", "second:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+
+    @Test
+    fun overrides_canReplacePluginExecutionPolicy() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+        val firstPluginStarted = CompletableDeferred<Unit>()
+        val secondPluginStarted = CompletableDeferred<Unit>()
+        val firstPluginCanFinish = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            records = records,
+            firstPluginStarted = firstPluginStarted,
+            secondPluginStarted = secondPluginStarted,
+            firstPluginCanFinish = firstPluginCanFinish,
+            setupPolicy = PluginExecutionPolicy.Concurrent,
+            overrides = {
+                pluginExecutionPolicy(PluginExecutionPolicy.InRegistrationOrder)
+            },
+        )
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        assertTrue(firstPluginStarted.isCompleted)
+        assertFalse(secondPluginStarted.isCompleted)
+        assertEquals(listOf("first:start"), records)
+
+        firstPluginCanFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("first:start", "first:end", "second:start", "second:end"),
+            records,
+        )
+        assertEquals(AppState(count = 1), store.currentState)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
@@ -58,14 +58,11 @@ class StorePluginTest {
                     onAction = { state, action ->
                         records += "action:$state:$action"
                     },
-                    onStateChanged = { prevState, state ->
-                        records += "state:$prevState->$state:current=$currentState"
+                    onState = { prevState, state ->
+                        records += "state:$prevState->$state"
                     },
                     onEvent = { state, event ->
                         records += "event:$state:$event"
-                    },
-                    onError = { state, error ->
-                        records += "error:$state:${error.message}"
                     },
                 ),
             )
@@ -111,14 +108,13 @@ class StorePluginTest {
         assertEquals(
             listOf(
                 "start:Loading",
-                "state:Loading->Ready(count=0):current=Ready(count=0)",
+                "state:Loading->Ready(count=0)",
                 "action:Ready(count=0):Increment",
-                "state:Ready(count=0)->Ready(count=1):current=Ready(count=1)",
+                "state:Ready(count=0)->Ready(count=1)",
                 "action:Ready(count=1):Emit",
                 "event:Ready(count=1):CountUpdated(count=1)",
                 "action:Ready(count=1):Throw",
-                "error:Ready(count=1):action failed",
-                "state:Ready(count=1)->Failed(message=action failed):current=Failed(message=action failed)",
+                "state:Ready(count=1)->Failed(message=action failed)",
             ),
             records,
         )
@@ -137,13 +133,15 @@ class StorePluginTest {
                     override suspend fun onStart(scope: PluginScope<AppState, AppAction>, state: AppState) {
                         scope.launch {
                             launchGate.await()
-                            records += "launch:${scope.currentState}"
+                            records += "launch:$currentState"
                         }
                     }
 
                     override suspend fun onAction(scope: PluginScope<AppState, AppAction>, state: AppState, action: AppAction) {
                         if (action == AppAction.TriggerPluginDispatch) {
-                            scope.dispatch(AppAction.Increment)
+                            scope.launch {
+                                dispatch(AppAction.Increment)
+                            }
                         }
                     }
                 },
@@ -195,7 +193,7 @@ class StorePluginTest {
                             try {
                                 kotlinx.coroutines.awaitCancellation()
                             } finally {
-                                records += "cleanup:${scope.currentState}"
+                                records += "cleanup:$currentState"
                             }
                         }
                     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
@@ -1,0 +1,238 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorePluginTest {
+
+    private class CountingStateSaver<S : State>(
+        private val restoredState: S? = null,
+    ) : StateSaver<S> {
+        var restoreCalls: Int = 0
+
+        override fun save(state: S) = Unit
+
+        override fun restore(): S? {
+            restoreCalls += 1
+            return restoredState
+        }
+    }
+
+    sealed interface AppState : State {
+        data object Loading : AppState
+        data class Ready(val count: Int = 0) : AppState
+        data class Failed(val message: String) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object Emit : AppAction
+        data object Throw : AppAction
+        data object TriggerPluginDispatch : AppAction
+    }
+
+    sealed interface AppEvent : Event {
+        data class CountUpdated(val count: Int) : AppEvent
+    }
+
+    @Test
+    fun pluginHooks_shouldObserveStoreLifecycle() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+
+        val store = Store<AppState, AppAction, AppEvent>(AppState.Loading) {
+            coroutineContext(testDispatcher)
+            plugin(
+                Plugin(
+                    onStart = { state ->
+                        records += "start:$state"
+                    },
+                    onAction = { state, action ->
+                        records += "action:$state:$action"
+                    },
+                    onStateChanged = { prevState, state ->
+                        records += "state:$prevState->$state:current=$currentState"
+                    },
+                    onEvent = { state, event ->
+                        records += "event:$state:$event"
+                    },
+                    onError = { state, error ->
+                        records += "error:$state:${error.message}"
+                    },
+                ),
+            )
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Ready())
+                }
+            }
+
+            state<AppState.Ready> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+
+                action<AppAction.Emit> {
+                    event(AppEvent.CountUpdated(count = state.count))
+                }
+
+                action<AppAction.Throw> {
+                    throw IllegalStateException("action failed")
+                }
+            }
+
+            state<AppState> {
+                error<Exception> {
+                    nextState(AppState.Failed(error.message ?: "unknown"))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        store.dispatch(AppAction.Emit)
+        runCurrent()
+
+        store.dispatch(AppAction.Throw)
+        runCurrent()
+
+        store.close()
+
+        assertEquals(
+            listOf(
+                "start:Loading",
+                "state:Loading->Ready(count=0):current=Ready(count=0)",
+                "action:Ready(count=0):Increment",
+                "state:Ready(count=0)->Ready(count=1):current=Ready(count=1)",
+                "action:Ready(count=1):Emit",
+                "event:Ready(count=1):CountUpdated(count=1)",
+                "action:Ready(count=1):Throw",
+                "error:Ready(count=1):action failed",
+                "state:Ready(count=1)->Failed(message=action failed):current=Failed(message=action failed)",
+            ),
+            records,
+        )
+    }
+
+    @Test
+    fun pluginScope_shouldAllowDispatchAndStoreScopedLaunch() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val launchGate = CompletableDeferred<Unit>()
+        val records = mutableListOf<String>()
+
+        val store = Store<AppState, AppAction, Nothing>(AppState.Loading) {
+            coroutineContext(testDispatcher)
+            plugin(
+                object : Plugin<AppState, AppAction, Nothing> {
+                    override suspend fun onStart(scope: PluginScope<AppState, AppAction>, state: AppState) {
+                        scope.launch {
+                            launchGate.await()
+                            records += "launch:${scope.currentState}"
+                        }
+                    }
+
+                    override suspend fun onAction(scope: PluginScope<AppState, AppAction>, state: AppState, action: AppAction) {
+                        if (action == AppAction.TriggerPluginDispatch) {
+                            scope.dispatch(AppAction.Increment)
+                        }
+                    }
+                },
+            )
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Ready())
+                }
+            }
+
+            state<AppState.Ready> {
+                action<AppAction.TriggerPluginDispatch> {
+                    // no-op
+                }
+
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.TriggerPluginDispatch)
+        runCurrent()
+
+        assertEquals(AppState.Ready(count = 1), store.currentState)
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        launchGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(AppState.Ready(count = 2), store.currentState)
+        assertEquals(listOf("launch:Ready(count=2)"), records)
+    }
+
+    @Test
+    fun pluginScopeLaunch_shouldRunFinallyOnStoreClose() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val records = mutableListOf<String>()
+
+        val store = Store<AppState, AppAction, Nothing>(AppState.Loading) {
+            coroutineContext(testDispatcher)
+            plugin(
+                object : Plugin<AppState, AppAction, Nothing> {
+                    override suspend fun onStart(scope: PluginScope<AppState, AppAction>, state: AppState) {
+                        scope.launch {
+                            try {
+                                kotlinx.coroutines.awaitCancellation()
+                            } finally {
+                                records += "cleanup:${scope.currentState}"
+                            }
+                        }
+                    }
+                },
+            )
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Ready())
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Increment)
+        runCurrent()
+
+        store.close()
+        advanceUntilIdle()
+
+        assertEquals(listOf("cleanup:Ready(count=0)"), records)
+    }
+
+    @Test
+    fun close_withoutPlugins_shouldNotInitializeStore() {
+        val stateSaver = CountingStateSaver<AppState>(restoredState = AppState.Ready(count = 10))
+        val store = Store<AppState, AppAction, Nothing>(AppState.Loading) {
+            stateSaver(stateSaver)
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Ready())
+                }
+            }
+        }
+
+        store.close()
+
+        assertEquals(0, stateSaver.restoreCalls)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Plugin` and `PluginScope` as a lighter store extension point alongside `Middleware`.
- Wire plugins into `StoreBuilder` and `StoreImpl`, add a `Plugin()` factory, and cover the behavior with tests.
- Document the plugin design, including cleanup via `launch { try/finally }` and the current thinking on execution policy.

## Why
- Provide a smaller extension surface for observation and integration use cases without expanding the existing middleware hook model.

## Verification
- `./gradlew :tart-core:jvmTest`