### PR TITLE
Add auto start policy to Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,9 @@ On platforms where Store's `.state` (StateFlow) and `.event` (Flow) cannot be co
 If the *State* or *Event* changes, you will be notified through these callbacks.
 These callbacks run in the Store's execution context. Tart does not automatically switch to a UI thread, so move to the appropriate UI thread before touching UI components when needed.
 
+Store startup is lazy. By default, the Store starts on the first `.dispatch(...)` or when state collection begins through `.state` or `.collectState()`.
+If you want state collection not to start the Store automatically, set `autoStartPolicy(AutoStartPolicy.OnDispatch)` and call `.start()` when you want to trigger startup explicitly.
+
 ## Compose
 
 <details>
@@ -1040,6 +1043,7 @@ Inside `overrides` block, you can use these APIs:
 - `coroutineContext(...)`
 - `stateSaver(...)`
 - `exceptionHandler(...)`
+- `autoStartPolicy(...)`
 - `plugin(...)`
 - `clearPlugins()`
 - `replacePlugins(...)`

--- a/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
+++ b/tart-compose/src/jvmTest/kotlin/io/yumemi/tart/compose/ViewStoreJvmTest.kt
@@ -261,6 +261,8 @@ private class TestStore(
     var closeCount: Int = 0
         private set
 
+    override fun start() = Unit
+
     override fun dispatch(action: UiAction) {
         dispatchedActions += action
     }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/AutoStartPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/AutoStartPolicy.kt
@@ -1,0 +1,21 @@
+package io.yumemi.tart.core
+
+/**
+ * Controls which actions implicitly start a lazy Store.
+ */
+enum class AutoStartPolicy {
+    /**
+     * Starts the Store when an action is dispatched or when state collection begins.
+     *
+     * This is the default behavior.
+     */
+    OnDispatchOrStateCollection,
+
+    /**
+     * Starts the Store when an action is dispatched.
+     *
+     * Collecting state alone does not start the Store. Use [Store.start] when you want to begin
+     * startup processing explicitly before the first dispatch.
+     */
+    OnDispatch,
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
@@ -11,8 +11,8 @@ enum class PendingActionPolicy {
     /**
      * Clears already queued actions after a transition to a different state variant is committed.
      * The currently running store work keeps running; only pending queued actions are discarded.
-     * Dispatches queued before a dispatch-triggered startup finishes are treated as post-start
-     * dispatches and are not discarded by that startup transition.
+     * Dispatches queued before startup finishes are treated as post-start dispatches and are not
+     * discarded by that startup transition, regardless of what triggered startup.
      */
     ClearOnStateExit,
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -7,8 +7,9 @@ import kotlinx.coroutines.flow.StateFlow
  * Core Tart interface for reading state, dispatching actions, and observing one-off events.
  *
  * Store startup is lazy.
- * Startup processing begins when an action is [dispatch]ed, when [state] starts being collected,
- * or when [collectState] is called.
+ * Startup processing begins when [start] is called, when an action is [dispatch]ed, and,
+ * with [AutoStartPolicy.OnDispatchOrStateCollection], when [state] starts being collected
+ * or [collectState] is called.
  * Collecting [event], calling [collectEvent], or reading [currentState] alone does not start the
  * Store.
  */
@@ -17,7 +18,8 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     /**
      * Hot stream of committed state snapshots.
      *
-     * Collecting this flow starts the Store if it has not started yet.
+     * Collecting this flow starts the Store if it has not started yet and the configured
+     * [AutoStartPolicy] includes state collection as a trigger.
      */
     val state: StateFlow<S>
 
@@ -39,6 +41,15 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
     val currentState: S
 
     /**
+     * Starts the Store if it has not started yet.
+     *
+     * This method returns immediately after requesting startup processing.
+     * It does not wait for startup to finish.
+     * Calling this method more than once has no additional effect after the first startup begins.
+     */
+    fun start()
+
+    /**
      * Enqueues an action for processing.
      *
      * This enqueues the action and returns immediately.
@@ -54,7 +65,8 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      * Collects committed state snapshots using a callback.
      *
      * This API is intended for platforms where [StateFlow] cannot be consumed directly.
-     * Calling this method starts the Store if it has not started yet.
+     * Calling this method starts the Store if it has not started yet and the configured
+     * [AutoStartPolicy] includes state collection as a trigger.
      *
      * The callback runs in the Store's execution context.
      * Tart does not switch to a UI thread automatically and does not guarantee delivery
@@ -73,8 +85,8 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      *
      * This API is intended for platforms where [Flow] cannot be consumed directly.
      * Calling this method does not start the Store by itself.
-     * If you need startup processing to run, also trigger startup through [dispatch], [state],
-     * or [collectState].
+     * If you need startup processing to run, also trigger startup through [start], [dispatch],
+     * [state], or [collectState].
      *
      * The callback runs in the Store's execution context.
      * Tart does not switch to a UI thread automatically and does not guarantee delivery

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -18,6 +18,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeCoroutineContext: CoroutineContext = Dispatchers.Default
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
+    private var storeAutoStartPolicy: AutoStartPolicy = AutoStartPolicy.OnDispatchOrStateCollection
     private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit
     private var storePluginExecutionPolicy: PluginExecutionPolicy = PluginExecutionPolicy.Concurrent
     private var storePlugins: MutableList<Plugin<S, A, E>> = mutableListOf()
@@ -61,6 +62,15 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         storeExceptionHandler = exceptionHandler
+    }
+
+    /**
+     * Sets which implicit triggers start a lazy Store.
+     *
+     * @param policy The auto-start policy to use
+     */
+    fun autoStartPolicy(policy: AutoStartPolicy) {
+        storeAutoStartPolicy = policy
     }
 
     /**
@@ -304,6 +314,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val coroutineContext: CoroutineContext = storeCoroutineContext
             override val stateSaver: StateSaver<S> = storeStateSaver
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
+            override val autoStartPolicy: AutoStartPolicy = storeAutoStartPolicy
             override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
             override val pluginExecutionPolicy: PluginExecutionPolicy = storePluginExecutionPolicy
             override val plugins: List<Plugin<S, A, E>> = storePlugins
@@ -324,7 +335,7 @@ typealias Setup<S, A, E> = StoreBuilder<S, A, E>.() -> Unit
  * Store overrides block applied after the main [Setup] block.
  *
  * This block is limited to non-state configuration such as coroutine context, persistence,
- * exception handling, pending action policy, and plugins.
+ * exception handling, auto-start policy, pending action policy, and plugins.
  */
 typealias Overrides<S, A, E> = StoreOverridesBuilder<S, A, E>.() -> Unit
 
@@ -357,6 +368,13 @@ class StoreOverridesBuilder<S : State, A : Action, E : Event> internal construct
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         operations.add { exceptionHandler(exceptionHandler) }
+    }
+
+    /**
+     * Overrides which implicit triggers start a lazy Store.
+     */
+    fun autoStartPolicy(policy: AutoStartPolicy) {
+        operations.add { autoStartPolicy(policy) }
     }
 
     /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -50,7 +50,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 launch {
                     _state.collect(collector)
                 }
-                launchStartup()
+                if (autoStartPolicy == AutoStartPolicy.OnDispatchOrStateCollection) {
+                    launchStartup()
+                }
                 awaitCancellation()
             }
         }
@@ -68,6 +70,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     protected abstract val stateSaver: StateSaver<S>
 
     protected abstract val exceptionHandler: ExceptionHandler
+
+    protected abstract val autoStartPolicy: AutoStartPolicy
 
     protected abstract val pendingActionPolicy: PendingActionPolicy
 
@@ -130,6 +134,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     final override fun dispatch(action: A) {
         launchDispatch(action)
+    }
+
+    final override fun start() {
+        launchStartup()
     }
 
     final override suspend fun startAndWait() {
@@ -678,7 +686,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     }
 
     private fun clearPendingActionsOnStateExitIfNeeded() {
-        if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && !(activeDispatchJob != null && !isInitialized)) {
+        // Previous behavior: protect only dispatch-triggered startup from pending dispatch cleanup.
+        // if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && !(activeDispatchJob != null && !isInitialized)) {
+        if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && isInitialized) {
             clearPendingDispatchJobs()
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -33,9 +33,11 @@ class StoreBaseTest {
 
     private fun createTestStore(
         initialState: AppState,
+        autoStartPolicy: AutoStartPolicy = AutoStartPolicy.OnDispatchOrStateCollection,
     ): Store<AppState, AppAction, AppEvent> {
         return Store(initialState) {
             coroutineContext(Dispatchers.Unconfined)
+            autoStartPolicy(autoStartPolicy)
             state<AppState.Loading> {
                 enter {
                     nextState(AppState.Main(count = 0))
@@ -87,12 +89,40 @@ class StoreBaseTest {
     }
 
     @Test
+    fun tartStore_withDispatchOnlyAutoStart_shouldNotProcessInitialEnterWhenCollectingState() = runTest(testDispatcher) {
+        val store = createTestStore(
+            initialState = AppState.Loading,
+            autoStartPolicy = AutoStartPolicy.OnDispatch,
+        )
+        var observedState: AppState? = null
+
+        store.collectState { state ->
+            observedState = state
+        }
+
+        assertEquals(AppState.Loading, observedState)
+        assertIs<AppState.Loading>(store.currentState)
+    }
+
+    @Test
     fun tartStore_dispatchBeforeStart_shouldInitializeAndHandleAction() = runTest(testDispatcher) {
         val store = createTestStore(AppState.Loading)
 
         store.dispatch(AppAction.Increment)
 
         assertEquals(AppState.Main(1), store.currentState)
+    }
+
+    @Test
+    fun tartStore_start_shouldInitializeWithoutDispatch() = runTest(testDispatcher) {
+        val store = createTestStore(
+            initialState = AppState.Loading,
+            autoStartPolicy = AutoStartPolicy.OnDispatch,
+        )
+
+        store.start()
+
+        assertEquals(AppState.Main(count = 0), store.currentState)
     }
 
     @Test
@@ -182,7 +212,7 @@ class StoreBaseTest {
     }
 
     @Test
-    fun tartStore_dispatchQueuedDuringStateCollectionStartup_shouldBeDroppedOnStateExit() = runTest(testDispatcher) {
+    fun tartStore_dispatchQueuedDuringStateCollectionStartup_shouldSurviveStateExit() = runTest(testDispatcher) {
         val startupEntered = CompletableDeferred<Unit>()
         val startupGate = CompletableDeferred<Unit>()
         val store: Store<AppState, AppAction, AppEvent> = Store(AppState.Loading) {
@@ -194,7 +224,11 @@ class StoreBaseTest {
                     nextState(AppState.Main(count = 0))
                 }
             }
-            state<AppState.Main> {}
+            state<AppState.Main> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
         }
 
         val collectingJob = launch {
@@ -213,7 +247,44 @@ class StoreBaseTest {
         dispatchJob.join()
         collectingJob.cancel()
 
-        assertEquals(AppState.Main(0), store.currentState)
+        assertEquals(AppState.Main(1), store.currentState)
+    }
+
+    @Test
+    fun tartStore_dispatchQueuedDuringExplicitStartup_shouldSurviveStateExit() = runTest(testDispatcher) {
+        val startupEntered = CompletableDeferred<Unit>()
+        val startupGate = CompletableDeferred<Unit>()
+        val store: Store<AppState, AppAction, AppEvent> = Store(AppState.Loading) {
+            coroutineContext(Dispatchers.Unconfined)
+            autoStartPolicy(AutoStartPolicy.OnDispatch)
+            state<AppState.Loading> {
+                enter {
+                    startupEntered.complete(Unit)
+                    startupGate.await()
+                    nextState(AppState.Main(count = 0))
+                }
+            }
+            state<AppState.Main> {
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+
+        store.start()
+        startupEntered.await()
+
+        val dispatchJob = launch {
+            store.dispatchAndWaitForTest(AppAction.Increment)
+        }
+
+        assertFalse(dispatchJob.isCompleted)
+        assertIs<AppState.Loading>(store.currentState)
+
+        startupGate.complete(Unit)
+        dispatchJob.join()
+
+        assertEquals(AppState.Main(1), store.currentState)
     }
 
     @Test

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreOverridesTest.kt
@@ -215,4 +215,31 @@ class StoreOverridesTest {
 
         assertEquals(PendingPolicyState.Active(value = 2), store.currentState)
     }
+
+    @Test
+    fun autoStartPolicyInOverrides_shouldOverrideSetupConfiguration() {
+        val store = Store<AppState, AppAction, Nothing>(
+            initialState = AppState(count = 0),
+            overrides = {
+                autoStartPolicy(AutoStartPolicy.OnDispatch)
+            },
+        ) {
+            coroutineContext(Dispatchers.Unconfined)
+            autoStartPolicy(AutoStartPolicy.OnDispatchOrStateCollection)
+
+            state<AppState> {
+                action<AppAction.Increment> {
+                    nextState(AppState(count = state.count + 1))
+                }
+            }
+        }
+
+        store.collectState { }
+
+        assertEquals(AppState(count = 0), store.currentState)
+
+        store.dispatch(AppAction.Increment)
+
+        assertEquals(AppState(count = 1), store.currentState)
+    }
 }

--- a/tart-test/src/commonTest/kotlin/io/yumemi/tart/test/StoreRecorderTest.kt
+++ b/tart-test/src/commonTest/kotlin/io/yumemi/tart/test/StoreRecorderTest.kt
@@ -163,6 +163,8 @@ class StoreRecorderTest {
         override val event: Flow<AppEvent> = emptyFlow()
         override val currentState: AppState = AppState.Loading
 
+        override fun start() = Unit
+
         override fun dispatch(action: AppAction) = Unit
 
         override fun collectState(state: (AppState) -> Unit) = Unit


### PR DESCRIPTION
## Summary
- add `AutoStartPolicy` and a public non-suspending `Store.start()` entrypoint
- allow state collection auto-start to be configured in setup and overrides while keeping dispatch-triggered startup as the default
- update startup and pending-dispatch tests, plus README and fake Store implementations used by tests

## Why
- support explicit startup ordering without forcing state collection to start the Store
- keep startup-trigger behavior configurable while preserving the existing default experience

## Verification
- ./gradlew :tart-core:jvmTest :tart-test:jvmTest :tart-compose:jvmTest