### PR TITLE
Add dispatch to PluginScope for use from hook bodies

### DIFF
--- a/doc/internal/notes/2026-05-02-plugin-design.md
+++ b/doc/internal/notes/2026-05-02-plugin-design.md
@@ -1,6 +1,6 @@
 # Plugin 設計メモ
 
-- 更新日: 2026-05-06
+- 更新日: 2026-05-09
 
 ## 背景
 
@@ -40,6 +40,8 @@ interface Plugin<S : State, A : Action, E : Event> {
 }
 
 interface PluginScope<S : State, A : Action> {
+    fun dispatch(action: A)
+
     fun launch(
         dispatcher: CoroutineDispatcher? = null,
         block: suspend LaunchScope<S, A>.() -> Unit,
@@ -82,10 +84,13 @@ state type change を見たい場合は、`onState` の中で `prevState::class 
 ### `PluginScope`
 
 `PluginScope` 自体は全 hook で使えるようにする。
-ただし、hook 本体では観測に寄せ、追加の権限は `launch {}` の中に閉じ込める。
+即時に return する fire-and-forget な操作は hook 本体からも呼べるようにし、長時間処理や継続的な購読、最新 state の参照といった「launch を必要とする操作」は `launch {}` の中に閉じ込める。
 
 scope に入れるのは次の最小セットで十分である。
 
+- `dispatch(action)`
+  - hook 本体から補助的な action を enqueue する
+  - `Store.dispatch` は元々 fire-and-forget なので、これだけのために `launch {}` を生やすのは余分な coroutine を作るだけになる
 - `launch { ... }`
   - Store-scoped な background work を開始する
 - `launch {}` 内の `LaunchScope.currentState`
@@ -124,6 +129,20 @@ override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
 
 この形なら、`Store.close()` でも親 scope cancel でも同じ cleanup が走る。
 cleanup の所有者が、その仕事自身の lifetime にぶら下がる点も分かりやすい。
+
+そもそも `Flow.collect` のような継続処理は、本体 Store の coroutine cancellation だけで停止するため、明示的な cleanup を書く機会自体が少ない。
+plugin の用途として代表的なものほど cleanup hook の出番がない、という意味でも、明示 close hook を導入する利得は薄い。
+
+### onError は持たない
+
+`Plugin` に例外通知用の `onError` hook を入れる案も考えられるが、現状では採らない。
+
+理由としては、`Plugin` の責務が観測と外部連携に寄っていることと整合しない為である。
+`onAction` / `onState` / `onEvent` はいずれも Store の **境界** を観測する hook であり、Store の入力（action）か出力（state / event）を見ている。
+一方で例外は Store 内部の error pipeline 上で起きる事象であり、これを hook として公開すると、plugin が Store 内部のロジックを覗き込む形になりやすい。
+
+ただし、将来的に Crashlytics 系プラグインへエラーをレポートするような要件が出てきた際には、再検討を行う価値はある。
+その際 `Store.exceptionHandler` で受けている、Store DSL 上の業務ロジック以外で起きたエラーは `onError` を plugin に足しても拾えない為、何を対象にレポートするかは合わせて検討する必要がある。
 
 ### execution policy は持つ
 
@@ -165,3 +184,4 @@ background work の完了順や、そこで起こした `dispatch()` の interle
 ## 関連
 
 - [Middleware 実行ポリシーは並行を標準にする](../adr/2026-04-23-middleware-execution-policy.md)
+- [`error {}` に流さない framework boundary の例外処理は当面現状維持とする](../adr/2026-05-07-framework-boundary-exception-handling.md)

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PluginScope.kt
@@ -7,7 +7,16 @@ import kotlinx.coroutines.CoroutineDispatcher
  *
  * Plugins can use this scope to start Store-scoped background work.
  */
+@TartStoreDsl
 interface PluginScope<S : State, A : Action> {
+    /**
+     * Dispatches an action to the Store.
+     *
+     * This enqueues the action and returns immediately.
+     * It does not wait for action handling to complete.
+     */
+    fun dispatch(action: A)
+
     /**
      * Starts background work in the Store's root coroutine scope and returns immediately.
      *
@@ -19,6 +28,7 @@ interface PluginScope<S : State, A : Action> {
     /**
      * Scope available within background work launched from a [Plugin].
      */
+    @TartStoreDsl
     interface LaunchScope<S : State, A : Action> {
         /**
          * The latest committed state snapshot.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -106,6 +106,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private val pluginScope by lazy {
         object : PluginScope<S, A> {
+            override fun dispatch(action: A) {
+                this@StoreImpl.dispatch(action)
+            }
+
             override fun launch(dispatcher: CoroutineDispatcher?, block: suspend PluginLaunchScope<S, A>.() -> Unit) {
                 coroutineScope.launch(dispatcher ?: EmptyCoroutineContext) {
                     block(

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePluginTest.kt
@@ -180,6 +180,45 @@ class StorePluginTest {
     }
 
     @Test
+    fun pluginScope_shouldAllowDispatchFromHookBody() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+
+        val store = Store<AppState, AppAction, Nothing>(AppState.Loading) {
+            coroutineContext(testDispatcher)
+            plugin(
+                object : Plugin<AppState, AppAction, Nothing> {
+                    override suspend fun onAction(scope: PluginScope<AppState, AppAction>, state: AppState, action: AppAction) {
+                        if (action == AppAction.TriggerPluginDispatch) {
+                            scope.dispatch(AppAction.Increment)
+                        }
+                    }
+                },
+            )
+
+            state<AppState.Loading> {
+                enter {
+                    nextState(AppState.Ready())
+                }
+            }
+
+            state<AppState.Ready> {
+                action<AppAction.TriggerPluginDispatch> {
+                    // no-op
+                }
+
+                action<AppAction.Increment> {
+                    nextState(state.copy(count = state.count + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.TriggerPluginDispatch)
+        advanceUntilIdle()
+
+        assertEquals(AppState.Ready(count = 1), store.currentState)
+    }
+
+    @Test
     fun pluginScopeLaunch_shouldRunFinallyOnStoreClose() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val records = mutableListOf<String>()


### PR DESCRIPTION
## Summary

- Expose `dispatch(action)` directly on `PluginScope` so Plugin hook bodies can dispatch without wrapping in `scope.launch { dispatch(...) }`.
- Add `@TartStoreDsl` to `PluginScope` and its inner `LaunchScope` to prevent a nested `launch { launch { ... } }` from implicitly resolving to the outer scope.

## Why

`Store.dispatch` is fire-and-forget and returns immediately, so the previous `scope.launch { dispatch(action) }` pattern was paying for an unnecessary coroutine just to call a non-suspending function. The new shape lets the role split read clearly:

| API | Role |
| --- | --- |
| `PluginScope.dispatch` | Immediate, non-blocking action injection from a hook body |
| `PluginScope.launch` | Separation from the Store main flow, dispatcher switch, or Store-scoped `Flow.collect` |

`@TartStoreDsl` is added for parity with `EnterScope` / `ActionScope` / `ErrorScope` / `ExitScope`, and to silently shadow the outer `PluginScope.launch` from inside a `scope.launch { ... }` block. Without the marker, calling `launch { ... }` again inside that block would silently resolve to the outer `PluginScope.launch`, which is almost never intended.

## Out of scope / intentionally not changed

- `nextState`, `event`, and `transaction` are deliberately still absent from `PluginScope`. State writes and event emission belong to `action {}` / `enter {}` to keep state-transition logic in one place.
- `PluginScope` is not added to the `StoreScope` sealed hierarchy. `StoreScope` documents itself as "DSL scopes exposed from Store handlers", and Plugin hooks are observers, not handlers — same DslMarker, separate type family.

## Test plan

- [x] Added `pluginScope_shouldAllowDispatchFromHookBody` in `StorePluginTest` covering `scope.dispatch` from `onAction` (no `launch` wrapper).
- [x] `./gradlew :tart-core:jvmTest --tests "io.yumemi.tart.core.StorePluginTest"` passes.
- [ ] CI green on all KMP targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)