### PR TITLE
Add notes on 3.1.0 to 4.0.0-beta01 changes

### DIFF
--- a/doc/internal/notes/2026-05-09-3.1.0-to-4.0.0-beta01-changes.md
+++ b/doc/internal/notes/2026-05-09-3.1.0-to-4.0.0-beta01-changes.md
@@ -1,0 +1,153 @@
+# 3.1.0 → 4.0.0-beta01 の変更整理
+
+- 更新日: 2026-05-09
+
+## 背景
+
+3.1.0 から 4.0.0-beta01 までで、Middleware → Plugin の置換、Store ライフサイクル制御の policy 化、`tart-test` 追加、Compose 連携の見直しなど、利用者が触れる API が広範囲に変わった。
+利用者が 3.1.0 から移行する際の参照と、4.0 で新しく使えるようになった機能の棚卸しのために、横断サマリとしてまとめておく。
+
+各論の理由は `adr/` 側に個別に残してあるので、ここでは何が変わったかと、移行時にどこを触るかだけを並べる。
+
+## A. 破壊的変更（3.1.0 のコードがそのまま動かなくなる箇所）
+
+### A-1. Middleware の全廃 → Plugin への置換
+
+- `Middleware<S, A, E>` / `MiddlewareScope<A>` 削除。`Plugin<S, A, E>` / `PluginScope<S, A>` に置換。
+  - 関連: `tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt`、`PluginScope.kt`
+- フック粒度を大幅に縮小。旧 12 フック（`before/afterActionDispatch`, `before/afterEventEmit`, `before/afterStateEnter`, `before/afterStateExit`, `before/afterStateChange`, `before/afterError`）はすべて削除。
+  - 新 API は `onStart` / `onAction` / `onState` / `onEvent` の 4 つだけ。
+  - `afterError` 系で再投入していた処理などは、`ExceptionHandler` か `error {}` ハンドラ側へ移す必要がある。
+- `StoreBuilder.middleware(...)` / `middlewares(...)` 削除。`plugin(first, vararg rest)` に置換。
+- `tart-logging`: `LoggingMiddleware` 抽象クラス削除。`simpleLogging(...)` は残るが戻り値は `Plugin`。
+- `tart-message`: `MessageMiddleware.kt` 削除。`receiveMessages(...)` は残るが戻り値は `Plugin`、ラムダレシーバが `MiddlewareScope<A>` → `PluginLaunchScope<S, A>`。
+
+### A-2. `Store` インタフェース
+
+- `dispose()` が `@Deprecated`。`close()` に統一。`Store` は `AutoCloseable` を継承。
+- `collectState(skipInitialState, startStore, state)` のフラグ 2 引数を削除。`collectState(state)` のみ。
+- 自動起動の挙動が `AutoStartPolicy` に統合され、デフォルトの `OnDispatchOrStateCollection` では `event` の collect では起動しない／`currentState` 読み取りでは起動しない。
+  - 3.1.0 で event 購読や `currentState` 参照のみで初期化が走ることを期待していたコードは要見直し。
+
+### A-3. `Store(...)` ファクトリ
+
+- 2 つあったオーバーロード（`Store(initialState, block)` / `Store(block)`）を 1 つに統合。
+  - 新シグネチャ: `Store(initialState: S? = null, context: CoroutineContext? = null, builder: StoreBuilder<...>.() -> Unit)`
+  - ラムダ引数名 `block` → `builder`。`block = ...` の名前付き呼び出しは壊れる。
+
+### A-4. DSL の引数名・既定値・型変更
+
+- `enter` / `action` / `exit` / `error` および `EnterScope.LaunchScope.transaction` などの DSL で、`coroutineDispatcher` → `dispatcher` に改名。
+- 型が `CoroutineDispatcher` → `CoroutineDispatcher?`、デフォルトが `Dispatchers.Unconfined` → `null`（= Store の context = 既定 `Dispatchers.Default` を継承）。
+  - `Unconfined` を前提としていたコードは挙動が変わる。
+- `error<T>` / `ErrorScope` の上限が `Throwable` → `Exception`。`error<Throwable>` や `error<OutOfMemoryError>` は不可。
+- `ExceptionHandler.Default` を削除し `ExceptionHandler.Unhandled` に改名（挙動は同じ: rethrow）。
+- `EnterScope<S, A, E, S2>` → `EnterScope<S, E, S2>`。型パラメータ `A` を削除。
+
+### A-5. tart-compose
+
+- `rememberViewStore(store, autoDispose)` → `rememberViewStore(key, autoClose, store)`。
+  - `store` 引数が `@Composable () -> Store<...>` ラムダになった。
+  - `autoDispose` → `autoClose` に改名。
+- `ViewStore.eventFlow` が `@PublishedApi internal`。外部から参照不可。
+- `ViewStore.render { ... }` の `block` は `@Composable` ラムダ必須。
+
+### A-6. tart-logging
+
+- `Logger` が `fun interface` 化。
+- `log(...)` から `suspend` を削除。
+- `message: String` → `message: () -> String`（遅延評価）。自前 `Logger` 実装は全部書き直し。
+- `simpleLogging(...)` の `coroutineDispatcher` → `dispatcher: CoroutineDispatcher?`、戻り値 `Plugin`。
+
+### A-7. その他
+
+- 新規 opt-in アノテーション `@InternalTartApi` を追加。3.1.0 で参照できていた一部 API が `internal` 化／要 opt-in 化されている可能性がある。
+
+## B. 4.0 で追加された新機能
+
+### B-1. 新モジュール `tart-test`
+
+公開 API は 2 ファイル: `tart-test/src/commonMain/kotlin/io/yumemi/tart/test/StoreExtensions.kt`、`StoreRecorder.kt`。
+
+- `suspend fun Store<...>.startAndWait()`
+  - `start()` のうち、プラグインの `onStart` と起動時の `enter {}` チェーンが終わるまで待つ。
+- `suspend fun Store<...>.dispatchAndWait(action)`
+  - その action 由来の handler 完了と同期的な遷移分まで待つ。`enter {}` / `action {}` から `launch` した分は待たない。
+- `Store<...>.patch { ... }`
+  - 起動前の Store に対し、`stateSaver` / `coroutineContext` / `exceptionHandler` / 各 `*Policy` / `plugin(...)` などを差し替える DSL。本番コードを変えずにテストで設定を上書きできる。
+- `Store<...>.createRecorder(): StoreRecorder<S, A, E>`
+  - Store に履歴記録用 Plugin を仕込み、`recorder.states` / `recorder.events` で時系列を取得できる。`clear()` 可能。
+
+### B-2. Plugin システム
+
+中核: `tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Plugin.kt`、`PluginScope.kt`。
+
+- 4 フックの `Plugin<S, A, E>` インタフェース、または `Plugin(onStart=…, onAction=…, onState=…, onEvent=…)` ファクトリで生成可能。
+- `PluginScope<S, A>` はフック本体から `dispatch(action)` 可能、`launch(dispatcher) { ... }` で Store 寿命の background 作業を投入できる。state を跨いで生き続け、`Store.close()` で終了。
+- `PluginLaunchScope<S, A>` 内では `currentState` も読める。
+- `PluginExecutionPolicy`: `Concurrent`（既定。並列で全完了を await）／`InRegistrationOrder`（登録順に逐次）。
+
+### B-3. ライフサイクル制御の 3 つの Policy
+
+- `AutoStartPolicy`: `OnDispatchOrStateCollection`（既定）／`OnDispatch`（state 購読では起動しない）。
+- `PendingActionPolicy`: `ClearOnStateExit`（既定。state バリアント遷移でキューイング済みの未実行 action を破棄）／`Keep`（明示的な `clearPendingActions()` 呼び出しまで保持）。
+- いずれも `StoreBuilder.autoStartPolicy(...)` / `pendingActionPolicy(...)` から設定。
+
+### B-4. `ActionScope` の launch / launch 制御
+
+3.1.0 では `EnterScope` のみ持っていた `launch` を、`ActionScope` も持つようになった。
+
+- `action {}` の中で `launch(dispatcher, control) { ... }`（→ `ActionLaunchScope` → `ActionTransactionScope`）。state 寿命の coroutine。
+- `LaunchControl`:
+  - `Concurrent`（既定。レーン管理なし）
+  - `CancelPrevious(lane)`（同レーンの前回を cancel して開始）
+  - `DropIfRunning(lane)`（同レーンの前回が走っている間は新規を捨てる）
+- `LaunchLane`: 明示レーン用キー。省略時は action 型ごとの暗黙レーン。
+- `ActionScope.cancelLaunch(LaunchLane)`: 明示レーン上のトラック中の launch を取り消し。
+- `enter {}` 内 `launch` / `transaction` の `dispatcher` パラメータが `null` 既定（Store の context 継承）になった点も新動作。
+
+### B-5. すべての通常スコープに共通の新 API
+
+`EnterScope` / `ActionScope` / `ExitScope` / `ErrorScope`、および各 `TransactionScope` に:
+
+- `clearPendingActions()`: キュー中の未実行 action だけ破棄（実行中の handler/transaction は止めない）。`PendingActionPolicy.Keep` 設定下での明示クリアにも使える。
+
+### B-6. `Store` 直接操作 API
+
+- `fun start()`: 明示的に起動を要求（即 return、完了は待たない。完了まで待ちたいときは `tart-test` の `startAndWait()`）。
+- `fun close()` ＋ `AutoCloseable` 実装: `use { ... }` で Store を閉じられる。
+
+### B-7. ファクトリ・ビルダー追加 DSL
+
+- `Store(initialState = …, context = …) { … }` の `context` 引数追加で、`coroutineContext(...)` を毎回書かずに済む。
+- `StoreBuilder` に `plugin(first, vararg rest)`、`autoStartPolicy(...)`、`pendingActionPolicy(...)`、`pluginExecutionPolicy(...)` を追加。
+
+### B-8. Patch API（公開は `tart-test` 経由）
+
+- `StorePatch` / `StorePatchBuilder`: non-state な Store 設定を起動前に上書き。`plugin(append)` / `replacePlugins(...)` / `clearPlugins()` でプラグイン構成も差し替え可能。
+- 直接の利用は `Store.patch { ... }`（`tart-test`）から。
+
+### B-9. tart-compose の補強
+
+- `rememberViewStore(key, autoClose, store)` のラムダ受け取り化により、Store の生成自体を Composable にできる（DI 経由の取得、`key` で再生成など）。
+- `ViewStore.handle { }` の `LaunchedEffect` キーが `eventFlow` ベースになり、Store の差し替え時に再購読される。
+- `ViewStore.render { }` が `@Composable` ラムダを取れるようになり、ネスト Composable をそのまま書ける。
+
+### B-10. tart-logging の表現力向上
+
+- `Logger.log(... message: () -> String)` の遅延評価で、disable 時のフォーマットコストを払わない。
+- `simpleLogging(...)` は `Plugin` として直接 `StoreBuilder.plugin(...)` に渡せる。
+
+## C. 移行影響度
+
+| 影響度 | 主な対象 |
+|---|---|
+| 必ず触る | Middleware → Plugin（`tart-logging` / `tart-message` 含む）／`Store(block)` オーバーロード／`ExceptionHandler.Default`／`rememberViewStore(store, autoDispose=…)` |
+| 使い方次第で触る | `collectState` のフラグ／`error<Throwable>`／`EnterScope` の型注釈／`Logger` 自前実装／`coroutineDispatcher = ...` 名前付き／`Store.dispose()` |
+| API は通るが挙動が変わる | `event` collect・`currentState` 読み取り単独では起動しない／`enter`・`action` ハンドラの既定 dispatcher が `Unconfined` → Store の context 継承 |
+| 4.0 で得られる新機能 | `tart-test`（recorder / patch / *AndWait）／`Plugin` 4 フック ＋ `PluginScope.launch`／`AutoStartPolicy` / `PendingActionPolicy` / `PluginExecutionPolicy`／`ActionScope.launch` ＋ `LaunchControl` / `LaunchLane` / `cancelLaunch`／全スコープの `clearPendingActions()`／`Store.start()` / `close()` / `AutoCloseable`／`Store(initialState, context) { }` |
+
+## 関連
+
+- `doc/internal/adr/` 配下の各 ADR（個別判断の根拠はそちらを参照）
+- `doc/internal/notes/2026-05-02-plugin-design.md`（Plugin の設計意図）


### PR DESCRIPTION
## Summary

- Add `doc/internal/notes/2026-05-09-3.1.0-to-4.0.0-beta01-changes.md` — a cross-cutting note that catalogs what changed between 3.1.0 and 4.0.0-beta01 from a user-migration perspective.
- Organized as: 背景 / A. 破壊的変更 (Middleware → Plugin, Store interface, factory, DSL renames, tart-compose, tart-logging, etc.) / B. 新機能 (`tart-test`, Plugin system, AutoStartPolicy / PendingActionPolicy / PluginExecutionPolicy, ActionScope.launch + LaunchControl, clearPendingActions, Store.start()/close(), patch API, etc.) / C. 移行影響度.
- Per-decision rationale stays in `adr/`. This note links back to `adr/` and to `notes/2026-05-02-plugin-design.md`.

## Why

The 3.1.0 → 4.0.0-beta01 window contains many independent changes scattered across ADRs. A single sweep is useful when supporting users migrating from 3.1.0 and when reviewing the surface area of 4.0.

## Test plan

- [ ] Verify the file renders correctly on GitHub.
- [ ] Confirm the file follows the `doc/internal/README.md` conventions (filename `YYYY-MM-DD-short-title.md`, `更新日:` metadata).