### PR TITLE
Add notes on AutoStartPolicy and ClearOnStateExit during startup

### DIFF
--- a/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
+++ b/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
@@ -1,0 +1,62 @@
+# AutoStartPolicy.OnDispatchOrStateCollection または AutoStartPolicy.OnDispatch の挙動について
+
+- 更新日: 2026-05-10
+
+## 背景
+
+`AutoStartPolicy.OnDispatchOrStateCollection`（default）と `AutoStartPolicy.OnDispatch` のいずれも、`dispatch()` を起点として Store の開始処理が走り得る。
+このとき、開始処理と dispatch の関係、特に `PendingActionPolicy.ClearOnStateExit` との相互作用について、UI 側から見たときの前提を整理しておく。
+
+## 現在の考え
+
+### dispatch 時の開始処理の見え方
+
+`dispatch()` 時に Store がまだ開始していなければ、開始処理を実行した上で、**開始処理完了後の state に対して本 dispatch および開始処理中に積まれた dispatch を適用する**仕組みである。
+
+つまり、dispatch する UI 側から見れば、Store の開始処理が実際にされている/されていないに関わらず、`dispatch()` する時点で「開始処理が終わっている」前提で書ける。
+開始処理が遅延しているせいで自分の dispatch が落ちる、という挙動を UI 側に意識させない。
+
+### PendingActionPolicy.ClearOnStateExit との関係
+
+開始処理中に state が変更され、かつ `PendingActionPolicy.ClearOnStateExit` の場合でも、**開始処理中の state class 遷移では本 dispatch および開始処理中の dispatch は削除しない**。
+
+実装上は、`clearPendingActionsOnStateExitIfNeeded()` が `isInitialized == true` のときだけ pending dispatch をクリアするようにしている（[StoreImpl.kt:729](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt:729)）。
+
+### 根拠: 構成フェーズには ClearOnStateExit がそもそも適用されない
+
+Store の lifecycle は 2 フェーズに分けられる。
+
+- **構成フェーズ**: Store 生成から startup 完了まで。初期 state の復元・確定、observer / overrides の固定、最初の `enter {}` 連鎖を含む。`currentState` はこの間、稼働中の state ではなく初期 state を確定する過程の placeholder。
+- **稼働フェーズ**: startup 完了以降。state は `dispatch()` でドライブする対象になる。
+
+この区切りは新しいものではなく、`stateSaver.restore()` / `attachObserver()` / `applyOverrides()` がすべて「startup 前のみ許可」になっていることと同じ線。
+
+`ClearOnStateExit` の意図は「**稼働中のある state class を狙って積まれた古い dispatch を、その state を抜けたら捨てる**」である（例: EditPost で積んだ `Save` を、PostList に遷移したら捨てる）。これが成立するのは稼働フェーズだけ。構成フェーズの `Loading → Main` は、利用者がまだ稼働窓に入っていないので「state exit」自体が定義できない。
+
+したがって、構成フェーズの遷移は `ClearOnStateExit` の **例外ではなく適用範囲外**。起点（dispatch / collect / `Store.start()`）に依存しないのも、フェーズ境界だけで決まるため。
+
+### 仕様文（案）
+
+> `PendingActionPolicy.ClearOnStateExit` は **稼働フェーズ**（startup 完了以降）の state class 遷移にのみ適用される。**構成フェーズ**（startup 完了まで）の遷移は初期 state 確定の過程であり、適用対象外。
+>
+> 利用者から見れば、startup の進行状況によらず `dispatch()` した時点で Store は稼働状態に入っている前提で書ける。
+
+### 補足: handler matching が暗黙の安全弁になる
+
+「構成フェーズが分岐して、想定外の state class に dispatch が着地する」リスクは理屈上ありうるが、Tart の handler matching は `(state class, action class)` ペアでマッチさせており、マッチしなければ **無音で no-op**（[StoreBuilder.kt:124-127](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt:124)）。
+
+そのため、たとえば `Loading → if 認証済 then Home else Login` の分岐 startup 中に `OpenPost` を dispatch しても、`Login` 側に `action<OpenPost>` が無ければそのまま破棄される。事故が起きるのは「同じ action を複数 state class で意図的に handle しており、かつ副作用が state ごとに異なる」場合に限られ、これは利用者が明示的にリスクを引き受けている setup である。
+
+つまり、構成フェーズで `ClearOnStateExit` が働かないことの実害は、handler matching の per-state class 設計によって大部分が吸収されている。
+
+## 補足
+
+- AutoStartPolicy に `Never` や `OnStateCollection` を追加する余地はあるが、優先度は低い。導入する場合の懸念として次がある。
+  - `Never`: Store の開始前に dispatch された action を捨てることになる、または例外を投げることになる。いずれも UI 側の負担が増える。
+  - `Never`: start 忘れに気づきづらい。
+  - `OnStateCollection`: `dispatch()` したのに start しないという挙動が直感に反しやすい。
+
+## 未解決事項
+
+- 上記「開始処理中の dispatch は ClearOnStateExit から除外する」挙動は、README やリファレンス側で明示されていないため、ドキュメント側に補記するかは要検討。
+- `AutoStartPolicy.Never` を将来追加する場合、start 前 dispatch を「例外」「破棄」「キュー保持」のどれにするかは別途決める必要がある。

--- a/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
+++ b/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
@@ -59,4 +59,4 @@ Store の lifecycle は 2 フェーズに分けられる。
 ## 未解決事項
 
 - 上記「開始処理中の dispatch は ClearOnStateExit から除外する」挙動は、README やリファレンス側で明示されていないため、ドキュメント側に補記するかは要検討。
-- `AutoStartPolicy.Never` を将来追加する場合、start 前 dispatch を「例外」「破棄」「キュー保持」のどれにするかは別途決める必要がある。
+- `AutoStartPolicy.Never` を将来追加する場合、start 前 dispatch の扱い（例外 / 破棄 / キュー保持）に加え、startup 中の dispatch を queue するか、startup 中の state 変更を `ClearOnStateExit` の対象とするかなど、いくつか論点を整理する必要がある。


### PR DESCRIPTION
## Summary

- Add an internal note on the interaction between `AutoStartPolicy` (`OnDispatchOrStateCollection` / `OnDispatch`) and `PendingActionPolicy.ClearOnStateExit` during Store startup.
- Frame the rule as a Store lifecycle distinction — **construction phase** (until startup completes) vs **running phase** (after startup) — and explain that `ClearOnStateExit` only applies to running-phase state class transitions. Construction-phase transitions are *out of scope* for `ClearOnStateExit`, not an exception to it. This aligns with existing pre-start-only rules for `stateSaver.restore()`, `attachObserver()`, and `applyOverrides()`.
- Note that the residual risk of dispatches landing in an unintended state class during a branching startup is largely absorbed by Tart's `(state class, action class)` handler matching, which silently no-ops on a miss.
- Capture open questions: documenting this in the README/reference, and what additional points (queueing, state transitions during startup) need to be settled if `AutoStartPolicy.Never` is introduced later.

## Test plan

- [ ] Documentation-only change.