### PR TITLE
Add async persistence plugin sketch to StateSaver ADR

### DIFF
--- a/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
+++ b/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
@@ -65,7 +65,7 @@ fun <S : State, A : Action, E : Event> AsyncStatePersistencePlugin(
 ### 利用イメージ
 
 ```kotlin
-store {
+Store {
     initialState = MyState.Loading
     plugin(
         AsyncStatePersistencePlugin(

--- a/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
+++ b/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
@@ -1,6 +1,6 @@
 # `StateSaver` は同期 snapshot API に限定する
 
-- 更新日: 2026-05-07
+- 更新日: 2026-05-11
 
 ## 背景
 
@@ -32,3 +32,74 @@ network / database / file I/O のような重い persistence の為に `suspend`
 - この判断により、`StateFlow` の初期値と `currentState` の同期性を保てる。
 - `enter {}` 自体が `suspend` なので、非同期 read のために `launch {}` は不要だが、startup を待たせずに並行に進めたい場合は `launch {}` を使う。
 - `Plugin.onState` 自体が `suspend` なので、非同期 write のために `launch {}` は不要だが、write 完了まで Store の進行を待たせたくない場合は `launch {}` を使う。
+
+## 非同期 persistence の Plugin による補助案
+
+ADR 本文の決定通り、`StateSaver` は同期に閉じる。一方で DataStore / file I/O / network のように suspend な read/write を伴う persistence を使いたい利用者は、`Loading` state + `enter {}` + `Plugin.onState` を毎回手で組む事になり、ボイラープレートが残る。
+このパターンを既存の Plugin API だけで codify する補助案を以下に記録する（決定ではなく設計メモ）。
+
+### 設計
+
+新しい top-level 抽象は追加せず、既存の Plugin（`onStart` / `onState` / `PluginScope.launch` / `dispatch`）だけで構成する。
+
+```kotlin
+fun <S : State, A : Action, E : Event> AsyncStatePersistencePlugin(
+    load: suspend () -> S?,
+    save: suspend (S) -> Unit,
+    onLoaded: (S) -> A,
+    onLoadFailed: ((Throwable) -> A)? = null,
+): Plugin<S, A, E> = Plugin(
+    onStart = { _ ->
+        launch {
+            runCatching { load() }
+                .onSuccess { restored -> if (restored != null) dispatch(onLoaded(restored)) }
+                .onFailure { e -> onLoadFailed?.let { dispatch(it(e)) } }
+        }
+    },
+    onState = { _, state ->
+        save(state)
+    },
+)
+```
+
+### 利用イメージ
+
+```kotlin
+store {
+    initialState = MyState.Loading
+    plugin(
+        AsyncStatePersistencePlugin(
+            load = { dataStore.data.first() },
+            save = { dataStore.updateData { _ -> it } },
+            onLoaded = MyAction::Restored,
+        )
+    )
+    state<MyState.Loading> {
+        action<MyAction.Restored> {
+            nextState { action.state }
+        }
+        action<MyAction.RestoreFailed> {
+            nextState { MyState.Empty }
+        }
+    }
+    state<MyState.Loaded> {
+        // 通常のハンドラ
+    }
+}
+```
+
+### ADR との整合
+
+- `StateSaver` の同期境界は崩さない。Plugin の組み合わせとして提供するだけなので本文の決定と矛盾しない。
+- 「重い I/O は `enter {}` / `Plugin.onState` に逃がす」という方針を、利用者が手で組まずに済むようパッケージ化したもの。
+
+### 制約とトレードオフ
+
+- `PluginScope` には state を直接書く API は無く（`dispatch` 経由のみ）、利用者は「復元成功 Action」と必要なら「復元失敗 Action」を定義する必要がある。これは one-way data flow を保つ意図的な制約。
+- Tart の DSL では `action {}` は `state {}` 配下にしか書けないため、復元 Action のハンドラは初期 state（典型的には `Loading`）配下にだけ書く。これは「復元 Action は初期 state でだけ意味を持つ」という意図と DSL 上整合する。
+
+### 配置と提供方針
+
+- `tart-core` 本体に DataStore 等の依存は持ち込まない。`load` / `save` を `suspend` ラムダで受ければ汎用に保てる。
+- 別モジュール（例: `tart-persistence`）またはサンプルとして提供する案。
+- `@ExperimentalTartApi` で出して、利用実態を見てから本流昇格を判断する。


### PR DESCRIPTION
## What
Append a new section to `doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md` recording a design sketch for an `AsyncStatePersistencePlugin` built on top of the existing `Plugin` API (`onStart` + `onState` + `PluginScope.launch` + `dispatch`). Also bump the ADR's `更新日` to 2026-05-11.

## Why
The ADR settles that `StateSaver` stays synchronous to preserve the `StateFlow` initial-value and `currentState` contracts. Users who need suspend-based persistence (DataStore, file I/O, network) currently have to wire up `Loading` state + `enter {}` + `Plugin.onState` by hand each time. The new section captures a Plugin-based way to codify that pattern without expanding `StateSaver` or introducing a new top-level abstraction, keeping the ADR's sync-snapshot boundary intact.

## Notes
- This is recorded as a design memo, not a decision — the section is explicit that it does not alter the ADR's conclusion.
- Internal doc only; no production code or public API changes.
- No tests run (docs-only change).