### PR TITLE
Document edge cases in StateSaver ADR and AutoStartPolicy notes

### DIFF
--- a/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
+++ b/doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md
@@ -32,6 +32,7 @@ network / database / file I/O のような重い persistence の為に `suspend`
 - この判断により、`StateFlow` の初期値と `currentState` の同期性を保てる。
 - `enter {}` 自体が `suspend` なので、非同期 read のために `launch {}` は不要だが、startup を待たせずに並行に進めたい場合は `launch {}` を使う。
 - `Plugin.onState` 自体が `suspend` なので、非同期 write のために `launch {}` は不要だが、write 完了まで Store の進行を待たせたくない場合は `launch {}` を使う。
+- `save()` だけを `suspend` にしたい（restore は同期で良い）場合は、`StateSaver` の責務を割らずに `Plugin.onState` から `suspend` な write を行う Plugin を別途用意すればよい。`StateSaver` の同期境界はそのまま保てる。
 
 ## 非同期 persistence の Plugin による補助案
 

--- a/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
+++ b/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
@@ -16,6 +16,17 @@
 つまり、dispatch する UI 側から見れば、Store の開始処理が実際にされている/されていないに関わらず、`dispatch()` する時点で「開始処理が終わっている」前提で書ける。
 開始処理が遅延しているせいで自分の dispatch が落ちる、という挙動を UI 側に意識させない。
 
+「開始処理中に積まれた dispatch」には、外部（UI 等）からの dispatch だけでなく、**`Plugin.onStart` 内部から発火された dispatch も含まれる**。`Plugin.onStart` は開始処理の一部として走るため、そこから dispatch されたものも同じレールに乗り、開始処理完了後の state に対して適用される。Plugin 作者側も「onStart で dispatch すると消える / 落ちる」といったエッジケースを意識せずに書ける。
+
+### collect / `Store.start()` 起点の場合
+
+開始処理のトリガーが `dispatch()` 以外の場合も同様の見え方になる。
+
+- `state` / `event` の collect が startup を起こす場合（`OnDispatchOrStateCollection`）: collect が開始処理のトリガーになるだけで、利用者から見たときの前提は dispatch 起点と同じ。
+- `Store.start()` を明示呼び出しする場合: 明示的に開始処理を走らせるだけで、その後の `dispatch()` / collect の挙動は通常通り。
+
+いずれの場合も「`dispatch()` 時点で開始処理が終わっている前提で書ける」のと同じ要領で、開始処理の内部挙動を意識せずに書ける。
+
 ### PendingActionPolicy.ClearOnStateExit との関係
 
 開始処理中に state が変更され、かつ `PendingActionPolicy.ClearOnStateExit` の場合でも、**開始処理中の state class 遷移では本 dispatch および開始処理中の dispatch は削除しない**。


### PR DESCRIPTION
## Summary

- StateSaver ADR (`doc/internal/adr/2026-05-07-statesaver-sync-snapshot-boundary.md`): note that callers wanting only `save()` to be `suspend` can use a `Plugin.onState`-based writer instead of splitting `StateSaver`'s responsibility, so the sync boundary stays intact.
- AutoStartPolicy notes (`doc/internal/notes/2026-05-10-auto-start-policy-behavior.md`): the document was dispatch-focused. Add explicit coverage for:
  - `collect` / `Store.start()` as startup triggers (same view as the dispatch case).
  - Dispatches fired from `Plugin.onStart` — they ride the same rail as externally-queued dispatches and are applied to the post-startup state.

Both files are under `doc/internal/`, no code changes.

## Test plan

- [x] Internal docs only — no build/test impact.