### PR TITLE
Expand AutoStartPolicy notes with implementation follow-up

### DIFF
--- a/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
+++ b/doc/internal/notes/2026-05-10-auto-start-policy-behavior.md
@@ -31,7 +31,13 @@
 
 開始処理中に state が変更され、かつ `PendingActionPolicy.ClearOnStateExit` の場合でも、**開始処理中の state class 遷移では本 dispatch および開始処理中の dispatch は削除しない**。
 
-実装上は、`clearPendingActionsOnStateExitIfNeeded()` が `isInitialized == true` のときだけ pending dispatch をクリアするようにしている（[StoreImpl.kt:729](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt:729)）。
+実装上は、`clearPendingActionsOnStateExitIfNeeded()` が `isInitialized == true` のときだけ pending dispatch をクリアするようにしている（[StoreImpl.kt:727](../../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt:727)）。
+
+#### 実装補足
+
+- 現状は collect / `Store.start()` 起点の場合でも、開始処理中の state class 遷移での dispatch 削除は行わないが、もし仮に将来、dispatch 起点のみの挙動とする場合は [StoreImpl.kt:727](../../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt:727) の判定を次のように変更する。
+  - `if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && !(activeDispatchJob != null && !isInitialized))`
+- 仮に将来、開始処理中の state class 遷移で dispatch を落とす要件が出てきた場合、単純に `clearPendingActionsOnStateExitIfNeeded()` の `isInitialized == true` の判定を削除するだけでは足りず、[StoreImpl.kt:194](../../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt:194) の mutex に既に入っている dispatch の onActionDispatched() の実行を防止する必要がある。
 
 ### 根拠: 構成フェーズには ClearOnStateExit がそもそも適用されない
 
@@ -54,7 +60,7 @@ Store の lifecycle は 2 フェーズに分けられる。
 
 ### 補足: handler matching が暗黙の安全弁になる
 
-「構成フェーズが分岐して、想定外の state class に dispatch が着地する」リスクは理屈上ありうるが、Tart の handler matching は `(state class, action class)` ペアでマッチさせており、マッチしなければ **無音で no-op**（[StoreBuilder.kt:124-127](../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt:124)）。
+「構成フェーズが分岐して、想定外の state class に dispatch が着地する」リスクは理屈上ありうるが、Tart の handler matching は `(state class, action class)` ペアでマッチさせており、マッチしなければ **無音で no-op**（[StoreBuilder.kt:124-127](../../../tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt:124)）。
 
 そのため、たとえば `Loading → if 認証済 then Home else Login` の分岐 startup 中に `OpenPost` を dispatch しても、`Login` 側に `action<OpenPost>` が無ければそのまま破棄される。事故が起きるのは「同じ action を複数 state class で意図的に handle しており、かつ副作用が state ごとに異なる」場合に限られ、これは利用者が明示的にリスクを引き受けている setup である。
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -724,8 +724,6 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     }
 
     private fun clearPendingActionsOnStateExitIfNeeded() {
-        // Previous behavior: protect only dispatch-triggered startup from pending dispatch cleanup.
-        // if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && !(activeDispatchJob != null && !isInitialized)) {
         if (pendingActionPolicy == PendingActionPolicy.ClearOnStateExit && isInitialized) {
             clearPendingDispatchJobs()
         }


### PR DESCRIPTION
## What

- Add an "実装補足" subsection to `doc/internal/notes/2026-05-10-auto-start-policy-behavior.md` that:
  - Records the alternative `clearPendingActionsOnStateExitIfNeeded()` condition we would use if we ever wanted dispatch-triggered startup to be the only protected case.
  - Notes that, if we ever wanted state-class transitions during startup to drop dispatches, removing the `isInitialized == true` guard alone is not enough — we'd also have to prevent the already-mutex-entered dispatch's `onActionDispatched()` from running.
- Fix the relative paths in the note's source links (`../../` → `../../../`) and refresh the `StoreImpl.kt` line numbers so they point at the current code.
- Remove the now-redundant inline "previous behavior" comment in `StoreImpl.clearPendingActionsOnStateExitIfNeeded()`; the same information now lives in the internal note where it has room to be explained.

## Why

The previous code carried the alternative-behavior recipe as a commented-out line, which is easy to miss and hard to reason about in isolation. Moving it into the internal design note keeps `StoreImpl.kt` cleaner and gives future maintainers the full context (including the additional mutex consideration) in one place.

## Impact

- No behavior change. Public API is untouched.
- Internal documentation only, plus a comment cleanup in `tart-core`.

## Verification

- No tests run; the only code change is the removal of two comment lines.