### PR TITLE
Bump actions to v5 for Node.js 24

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,20 +35,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - uses: actions/cache@v4
+        uses: gradle/actions/wrapper-validation@v5
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
+        uses: gradle/actions/setup-gradle@v5
         with:
           arguments: ${{ matrix.target }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Build with Gradle
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-        with:
-          arguments: ${{ matrix.target }}
+      - name: Build with Gradle
+        run: ./gradlew ${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 21


### PR DESCRIPTION
This PR updates the GitHub Actions used in this action:

- `actions/checkout` from v4 to v5
- `actions/cache` from v4 to v5
- `actions/setup-java` from v3 to v5
- `gradle/actions/wrapper-validation` to `gradle/actions/wrapper-validation` v5
- `gradle/actions/gradle-build-action` to `gradle/actions/setup-gradle` v5

These updates address the Node.js 20 deprecation warning and align the action with the latest supported Node.js runtime.

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/setup-java@v3, gradle/actions/wrapper-validation@v4, gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Note
The latest version is available, but it includes additional significant changes.

- `actions/checkout` v7
- `actions/cache` v7
- `gradle/actions/` v6

To keep this PR focused on fixing the Node.js deprecation warning, upgrading to latest version is considered out of scope and can be handled in a separate PR.